### PR TITLE
BUG: Remove tensorflow from conda-build

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - pydantic
     - numpy
     - pyyaml
-    - tensorflow
 
 test:
   imports:
@@ -30,6 +29,7 @@ test:
   requires:
     - pytest
   commands:
+    - pip install tensorflow
     - py.test --pyargs lume_model
 
 about:


### PR DESCRIPTION
The conda tensorflow build is broken with python 3.8. Python 3.8 will require > 2.2