### PR TITLE
Bug fix for output parsing

### DIFF
--- a/lume_model/utils.py
+++ b/lume_model/utils.py
@@ -236,6 +236,9 @@ def model_from_yaml(
 
             model_kwargs.update(config["model"]["kwargs"])
 
+        if "output_format" in config["model"]:
+            model_kwargs["output_format"] = config["model"]["output_format"]
+
     if model_class is None:
         logger.exception("No model class found.")
         sys.exit()


### PR DESCRIPTION
Output format was not updated in the model configuration resulting in incorrect setting of example output for keras iris example in lume-epics