### PR TITLE
Fix tf load

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -163,7 +163,7 @@ input_variables:
 
 ## Keras/tensorflow toolkit
 
-At present, only the tensorflow backend is supported for this toolkit.
+At present, only the tensorflow v2 backend is supported for this toolkit.
 
 The `KerasModel` packaged in the toolkit will be compatible with models saved using the `keras.save_model()` method.
 

--- a/lume_model/keras/README.md
+++ b/lume_model/keras/README.md
@@ -1,6 +1,6 @@
 # Model development with the Keras/tensorflow toolkit
 
-At present, only the tensorflow backend is supported for this toolkit.
+At present, only the tensorflow v2 backend is supported for this toolkit.
 
 The `KerasModel` packaged in the toolkit will be compatible with models saved using the `keras.save_model()` method.
 

--- a/lume_model/keras/__init__.py
+++ b/lume_model/keras/__init__.py
@@ -12,7 +12,6 @@ from lume_model.keras.layers import ScaleLayer, UnscaleLayer, UnscaleImgLayer
 
 logger = logging.getLogger(__name__)
 
-
 base_layers = {
     "ScaleLayer": ScaleLayer,
     "UnscaleLayer": UnscaleLayer,
@@ -64,9 +63,7 @@ class KerasModel(SurrogateModel):
         base_layers.update(custom_layers)
 
         # load model in thread safe manner
-        self._thread_graph = tf.Graph()
-        with self._thread_graph.as_default():
-            self._model = load_model(model_file, custom_objects=base_layers,)
+        self._model = load_model(model_file, custom_objects=base_layers,)
 
     def evaluate(self, input_variables: List[InputVariable]) -> List[OutputVariable]:
         """Evaluate model using new input variables.
@@ -90,8 +87,7 @@ class KerasModel(SurrogateModel):
         formatted_input = self.format_input(input_dictionary)
 
         # call prediction in threadsafe manner
-        with self._thread_graph.as_default():
-            model_output = self._model.predict(formatted_input)
+        model_output = self._model.predict(formatted_input)
 
         output = self.parse_output(model_output)
 

--- a/lume_model/tests/test_files/iris_config.yml
+++ b/lume_model/tests/test_files/iris_config.yml
@@ -4,7 +4,7 @@ model:
     requirements:
       tensorflow: 2.3.1
     kwargs:
-      model_file: examples/files/iris_model.h5
+      model_file: lume_model/tests/test_files/iris_model.h5
     output_format:
         type: softmax
 


### PR DESCRIPTION
These changes remove the v1 thread compatible implicit declaration of session and graph. With 2, model loading in these scopes was leading to issues with version 2 behavior enabled. Because the model executes in a single thread, there is no need for concern about threading.