### PR TITLE
Enforce pinned pydantic

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - pip
   run:
     - python
-    - pydantic
+    - pydantic>=1.6.1,<1.8.2
     - numpy
     - pyyaml
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,6 @@ black
 pre-commit
 pytest
 numpy
-pydantic>=1.6.1
+pydantic>=1.6.1,<1.8.2
 doctr
 pyyaml

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -2,7 +2,7 @@ black
 pre-commit
 pytest
 numpy
-pydantic>=1.6.1
+pydantic>=1.6.1,<1.8.2
 doctr
 pyyaml
 mkdocs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pydantic>=1.6.1
+pydantic>=1.6.1,<1.8.2
 numpy
 pyyaml


### PR DESCRIPTION
The latest version of pydantic has introduced a bug that fails on some value verification tests. This PR pins, requiring a lower version.