### PR TITLE
Nans and increment pydantic

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,10 +16,10 @@ requirements:
     - python
     - setuptools
     - pip
-    - pydantic >=1.6.1,<1.8.2
+    - pydantic
   run:
     - python
-    - pydantic >=1.6.1,<1.8.2
+    - pydantic
     - numpy
     - pyyaml
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,5 +2,5 @@ black
 pre-commit
 pytest
 numpy
-pydantic>=1.6.1,<1.8.2
+pydantic
 pyyaml

--- a/lume_model/tests/test_variables.py
+++ b/lume_model/tests/test_variables.py
@@ -16,6 +16,7 @@ from lume_model.variables import (
     [
         ("test", 0.1, [0.1, 2]),
         pytest.param("test", np.array([1, 2, 3, 4]), [0, 1], marks=pytest.mark.xfail),
+        ("test", np.nan, [0, 1]),
     ],
 )
 def test_input_scalar_variable(variable_name, default, value_range):
@@ -91,6 +92,7 @@ def test_output_scalar_variable(variable_name, default, value_range):
         pytest.param(
             "test", 1.0, [0, 1], ["x", "y"], 0, 0, 1, 1, marks=pytest.mark.xfail
         ),
+        ("test", np.empty((3, 3)), [0, 1], ["x", "y"], 0, 0, 1, 1),
     ],
 )
 def test_input_image_variable(

--- a/lume_model/variables.py
+++ b/lume_model/variables.py
@@ -391,7 +391,7 @@ class ImageOutputVariable(OutputVariable[Image], ImageVariable):
     y_max: Optional[float] = None
 
 
-class ScalarInputVariable(InputVariable[Union[float, type(None)]], ScalarVariable):
+class ScalarInputVariable(InputVariable[Union[float]], ScalarVariable):
     """
     Variable used for representing an scalar input. Scalar variables hold float values.
     Initialization requires name, default, and value_range.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pydantic>=1.6.1,<1.8.2
+pydantic
 numpy
 pyyaml


### PR DESCRIPTION
The pydantic issue was introduced with the None typing on the Scalar input variable. This PR drops that typing for use of np.nan for null values and introduces tests with nans.