### PR TITLE
Fix versioneer.py for Python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9"]
+        python-version: ["3.9", "3.12"]
 
     name: Python ${{ matrix.python-version }}, ${{ matrix.os }} build
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9"]
 
     name: Python ${{ matrix.python-version }}, ${{ matrix.os }} build
     steps:

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -3,7 +3,7 @@ name: lume-model-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python>=3.9
   - pydantic>2.3
   - numpy
   - pyyaml

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - numpy
   - pyyaml
   - tensorflow
-  - keras<3
   - botorch<0.11
 
   # dev requirements

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ name: lume-model
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python>=3.9
   - pydantic>2.3
   - numpy
   - pyyaml

--- a/versioneer.py
+++ b/versioneer.py
@@ -343,9 +343,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
It seems that `SafeConfigParser` has been replaced by `ConfigParser` (optional since `Python 3.2`, required since `Python 3.12`)
https://docs.python.org/3/whatsnew/3.2.html#configparser
https://docs.python.org/3/whatsnew/3.12.html#configparser

Similarly, the method `read_file` seems to now replace `readfp`:
https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file

This PR also adds an automated test with Python 3.12 (in addition to the existing automated test with Python 3.9)