### PR TITLE
Add global random seed for deterministic tests

### DIFF
--- a/tests/models/test_torch_model.py
+++ b/tests/models/test_torch_model.py
@@ -10,6 +10,8 @@ try:
     from botorch.models.transforms.input import AffineInputTransform
     from lume_model.models import TorchModel
     from lume_model.variables import ScalarVariable
+
+    torch.manual_seed(42)
 except ImportError:
     pass
 

--- a/tests/models/test_torch_model.py
+++ b/tests/models/test_torch_model.py
@@ -13,6 +13,7 @@ try:
 except ImportError:
     pass
 
+random.seed(42)
 
 def assert_model_equality(m1: TorchModel, m2: TorchModel):
     assert m1.input_variables == m2.input_variables

--- a/tests/models/test_torch_module.py
+++ b/tests/models/test_torch_module.py
@@ -9,6 +9,8 @@ try:
     import torch
     from botorch.models import SingleTaskGP
     from lume_model.models import TorchModel, TorchModule
+
+    torch.manual_seed(42)
 except ImportError:
     pass
 

--- a/tests/models/test_torch_module.py
+++ b/tests/models/test_torch_module.py
@@ -12,6 +12,7 @@ try:
 except ImportError:
     pass
 
+random.seed(42)
 
 def assert_california_module_result(result: torch.Tensor, idx=None):
     target = torch.tensor([4.0636503726, 2.7774916915, 2.7928111793], dtype=result.dtype)


### PR DESCRIPTION
### Description

This PR introduces a global random seed set after imports in the test file. This change aims to make the tests more deterministic and easier to debug by ensuring consistent random behavior across test runs.

### Current Issues (Before this PR):

The tests currently use random without setting a fixed seed, which causes several problems :

a. Flaky Tests: Tests sometimes pass and sometimes fail due to different random values;
b. Hard to Reproduce: When a test fails, it's difficult to reproduce the exact conditions;
c. Inconsistent CI/CD: Different CI runs may have different outcomes;
d. Time Wasted: Developers spend time debugging issues that are hard to replicate.

(Im not saying these problems are happening, but they can happen.)

### Solution

Set a global random seed right after imports in the test file.

### Benefits

a. Reproducibility: All test runs will use the same random values;
b. Easier Debugging: When a test fails, we can easily reproduce the issue;
c. Consistent CI/CD: Every CI run will have the same behavior;
d. Clear Intent: It's immediately obvious that we're using controlled randomness;
e. Time Saved: Less time spent on debugging non-deterministic test failures.
