### PR TITLE
Temporarily remove CI tests involving keras

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run Tests
         shell: bash -l {0}
         run: |
-          pytest -ra --pyargs tests
+          pytest -ra --pyargs tests -k "not keras"
 
       - name: Build package
         shell: bash -l {0}


### PR DESCRIPTION
This uses `pytest`'s `-k` syntax to specify a keyword expression, using the `not` operator to **exclude** tests that match the keyword.