### PR TITLE
Support torch.nn.Linear transformers

### DIFF
--- a/examples/transformer_conversion.ipynb
+++ b/examples/transformer_conversion.ipynb
@@ -1,0 +1,146 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "235c92cd-cc05-42b8-a516-1185eeac5f0c",
+   "metadata": {},
+   "source": [
+    "# Transformer Conversion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "56725817-2b21-4bea-98b0-151dea959f77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import torch\n",
+    "from botorch.models.transforms.input import AffineInputTransform\n",
+    "\n",
+    "sys.path.append(\"../\")\n",
+    "from lume_model.models import TorchModel, TorchModule"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9feaf8a2-f533-4787-a588-22aba0844e53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load exemplary model\n",
+    "torch_model = TorchModel(\"../tests/test_files/california_regression/torch_model.yml\")\n",
+    "torch_module = TorchModule(model=torch_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9ab4f3bf-cfb6-43f8-beaa-3847d7caf1bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# conversion\n",
+    "def convert_torch_transformer(t: torch.nn.Linear) -> AffineInputTransform:\n",
+    "    \"\"\"Creates an AffineInputTransform module which mirrors the behavior of the given torch.nn.Linear module.\n",
+    "\n",
+    "    Args:\n",
+    "        t: The torch transformer to convert.\n",
+    "\n",
+    "    Returns:\n",
+    "        AffineInputTransform module which mirrors the behavior of the given torch.nn.Linear module.\n",
+    "    \"\"\"\n",
+    "    m = AffineInputTransform(\n",
+    "        d=t.bias.size(-1),\n",
+    "        coefficient=1 / t.weight.diagonal(),\n",
+    "        offset=-t.bias / t.weight.diagonal(),\n",
+    "    ).to(t.bias.dtype)\n",
+    "    m.offset.requires_grad = t.bias.requires_grad\n",
+    "    m.coefficient.requires_grad = t.weight.requires_grad\n",
+    "    if not t.training:\n",
+    "        m.eval()\n",
+    "    return m\n",
+    "\n",
+    "\n",
+    "def convert_botorch_transformer(t: AffineInputTransform) -> torch.nn.Linear:\n",
+    "    \"\"\"Creates a torch.nn.Linear module which mirrors the behavior of the given AffineInputTransform module.\n",
+    "\n",
+    "    Args:\n",
+    "        t: The botorch transformer to convert.\n",
+    "\n",
+    "    Returns:\n",
+    "        torch.nn.Linear module which mirrors the behavior of the given AffineInputTransform module.\n",
+    "    \"\"\"\n",
+    "    d = t.offset.size(-1)\n",
+    "    m = torch.nn.Linear(in_features=d, out_features=d).to(t.offset.dtype)\n",
+    "    m.bias = torch.nn.Parameter(-t.offset / t.coefficient)\n",
+    "    weight_matrix = torch.zeros((d, d))\n",
+    "    weight_matrix = weight_matrix.fill_diagonal_(1.0) / t.coefficient\n",
+    "    m.weight = torch.nn.Parameter(weight_matrix)\n",
+    "    m.bias.requires_grad = t.offset.requires_grad\n",
+    "    m.weight.requires_grad = t.coefficient.requires_grad\n",
+    "    if not t.training:\n",
+    "        m.eval()\n",
+    "    return m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ff3bfd02-dbc1-4236-9ff6-77c4f8a7dcb2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# test on exemplary input\n",
+    "input_dict = torch_model.random_input(n_samples=1)\n",
+    "x = torch.tensor([input_dict[k] for k in torch_module.input_order]).unsqueeze(0)\n",
+    "botorch_transformer = torch_model.input_transformers[0].to(x.dtype)\n",
+    "torch_transformer = convert_botorch_transformer(botorch_transformer)\n",
+    "converted_botorch_transformer = convert_torch_transformer(torch_transformer)\n",
+    "\n",
+    "print(torch.all(torch.isclose(botorch_transformer(x), torch_transformer(x), atol=1e-6)).item())\n",
+    "print(torch.all(torch.isclose(torch_transformer(x), converted_botorch_transformer(x), atol=1e-6)).item())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b96c564-7037-4a2c-8f46-2f84fc75c2e2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:lume-model-dev]",
+   "language": "python",
+   "name": "conda-env-lume-model-dev-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.20"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/transformer_conversion.ipynb
+++ b/examples/transformer_conversion.ipynb
@@ -96,7 +96,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "True\n",
       "True\n"
      ]
     }
@@ -105,18 +104,29 @@
     "# test on exemplary input\n",
     "input_dict = torch_model.random_input(n_samples=1)\n",
     "x = torch.tensor([input_dict[k] for k in torch_module.input_order]).unsqueeze(0)\n",
-    "botorch_transformer = torch_model.input_transformers[0].to(x.dtype)\n",
-    "torch_transformer = convert_botorch_transformer(botorch_transformer)\n",
-    "converted_botorch_transformer = convert_torch_transformer(torch_transformer)\n",
     "\n",
-    "print(torch.all(torch.isclose(botorch_transformer(x), torch_transformer(x), atol=1e-6)).item())\n",
-    "print(torch.all(torch.isclose(torch_transformer(x), converted_botorch_transformer(x), atol=1e-6)).item())"
+    "torch_input_transformers = [\n",
+    "    convert_botorch_transformer(t) for t in torch_model.input_transformers\n",
+    "]\n",
+    "torch_output_transformers = [\n",
+    "    convert_botorch_transformer(t) for t in torch_model.output_transformers\n",
+    "]\n",
+    "new_torch_model = TorchModel(\n",
+    "    input_variables=torch_model.input_variables,\n",
+    "    output_variables=torch_model.output_variables,\n",
+    "    model=torch_model.model,\n",
+    "    input_transformers=torch_input_transformers,\n",
+    "    output_transformers=torch_output_transformers,\n",
+    ")\n",
+    "new_torch_module = TorchModule(model=new_torch_model)\n",
+    "\n",
+    "print(torch.isclose(torch_module(x), new_torch_module(x)).item())"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b96c564-7037-4a2c-8f46-2f84fc75c2e2",
+   "id": "a45608c5-dae7-48f7-b602-b2bcd6e9d453",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Adds the option to specify input and output transformers as `torch.nn.Linear` modules. The conversion from and to the `BoTorch` version (`AffineInputTransform`) is illustrated in an exemplary notebook. This change should facilitate [saving and loading models in the TorchScript format](https://pytorch.org/tutorials/beginner/saving_loading_models.html#saving-loading-model-for-inference).