### PR TITLE
add jit filename to yaml and load jit if available

### DIFF
--- a/lume_model/base.py
+++ b/lume_model/base.py
@@ -77,7 +77,7 @@ def process_torch_module(
                 "for NN models that don't depend on BoTorch modules.")
             logger.error(f"Failed to script the model: {e}")
             raise e
-    return jit_filename if not save_modules and save_jit else filename
+    return jit_filename if save_jit else filename
 
 def recursive_serialize(
         v: dict[str, Any],

--- a/lume_model/models/torch_model.py
+++ b/lume_model/models/torch_model.py
@@ -89,8 +89,10 @@ class TorchModel(LUMEBaseModel):
             if os.path.exists(v):
                 try:
                     v = torch.jit.load(v)
+                    print(f"Loaded TorchScript (JIT) model from file: {v}")
                 except RuntimeError:
                     v = torch.load(v, weights_only=False)
+                    print(f"Loaded PyTorch model from file: {v}")
             else:
                 raise OSError(f"File {v} is not found.")
         return v

--- a/lume_model/models/torch_model.py
+++ b/lume_model/models/torch_model.py
@@ -87,7 +87,10 @@ class TorchModel(LUMEBaseModel):
     def validate_torch_model(cls, v):
         if isinstance(v, (str, os.PathLike)):
             if os.path.exists(v):
-                v = torch.load(v)
+                try:
+                    v = torch.jit.load(v)
+                except RuntimeError:
+                    v = torch.load(v, weights_only=False)
             else:
                 raise OSError(f"File {v} is not found.")
         return v
@@ -100,7 +103,7 @@ class TorchModel(LUMEBaseModel):
         for t in v:
             if isinstance(t, (str, os.PathLike)):
                 if os.path.exists(t):
-                    t = torch.load(t)
+                    t = torch.load(t,  weights_only=False)
                 else:
                     raise OSError(f"File {t} is not found.")
             loaded_transformers.append(t)


### PR DESCRIPTION
Previously, if `save_jit` was equal to true, a JIT file was being saved but not specified in the YAML unless the model saved with `torch.save` file did not exist. In this PR, if `save_jit` is set to true, the YAML file will always have the model value as the JIT filename, and when loading  `TorchModel('filename.yml')`, `torch.load.jit` is attempted first, then `torch.load` if a JIT file is not found.