### PR TITLE
Adjust inputs order for prob models/gps, add mlflow to main requs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ LUME-model holds data structures used in the LUME modeling toolset. Variables an
 * pydantic
 * numpy
 * pyyaml
+* mlflow
 
 ## Install
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - numpy
   - pyyaml
   - botorch
+  - mlflow
 
   # dev requirements
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -7,3 +7,4 @@ dependencies:
   - pydantic>2.3
   - numpy
   - pyyaml
+  - mlflow

--- a/lume_model/models/gp_model.py
+++ b/lume_model/models/gp_model.py
@@ -142,6 +142,8 @@ class GPModel(ProbModelBaseModel):
         Returns:
             Dictionary of output variable names to distributions.
         """
+        # Reorder the input dictionary to match the model's input order
+        input_dict = super()._arrange_inputs(input_dict)
         # Create tensor from input_dict
         x = super()._create_tensor_from_dict(input_dict)
         # Transform the input

--- a/lume_model/models/prob_model_base.py
+++ b/lume_model/models/prob_model_base.py
@@ -58,6 +58,19 @@ class ProbModelBaseModel(LUMEBaseModel):  # TODO: brainstorm a better name
                 f"expected one of ['double', 'single']."
             )
 
+    def _arrange_inputs(
+        self, d: dict[str, Union[float, torch.Tensor]]
+    ) -> dict[str, Union[float, torch.Tensor]]:
+        """Enforces order of input variables before creating a tensor.
+
+        Args:
+            d: Dictionary of input variable names to tensors.
+
+        Returns:
+            Ordered input tensor.
+        """
+        return {k: d[k] for k in self.input_names}
+
     @staticmethod
     def _create_tensor_from_dict(
         d: dict[str, Union[float, torch.Tensor]],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ requires-python = ">=3.10"
 dependencies = [
     "pydantic",
     "numpy",
-    "pyyaml"
+    "pyyaml",
+    "mlflow"
 ]
 dynamic = ["version"]
 [tool.setuptools_scm]
@@ -34,8 +35,7 @@ dev = [
     "botorch",
     "torch",
     "pre-commit",
-    "pytest",
-    "mlflow"
+    "pytest"
 ]
 docs = [
     "mkdocs",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pydantic
 numpy
 pyyaml
+mlflow


### PR DESCRIPTION
Fixes issue reported today during the NESAP meeting. 

- probabilistic models abstract class now has method to reorder inputs based on the order defined in `input_variables`
- mlflow is now in the base dependencies