### PR TITLE
Fix MLflow type hint/signature warnings

### DIFF
--- a/examples/mlflow_integration/example_update_input_variables_to_calibration_transformer_mlflow.ipynb
+++ b/examples/mlflow_integration/example_update_input_variables_to_calibration_transformer_mlflow.ipynb
@@ -5,16 +5,7 @@
    "execution_count": 1,
    "id": "aa524ea8-c3dc-41ff-8ff2-618872e133a6",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/smiskov/miniconda3/envs/lume-latest/lib/python3.10/site-packages/mlflow/pyfunc/model.py:175: UserWarning: \u001b[31mType hint used in the model's predict function is not supported for MLflow's schema validation. Type hints must be wrapped in list[...] because MLflow assumes the predict method to take multiple input instances. Specify your type hint as `list[typing.Dict[str, typing.Any]]` for a valid signature. Remove the type hint to disable this warning. To enable validation for the input data, specify input example or model signature when logging the model. \u001b[0m\n",
-      "  func_info = _get_func_info_if_type_hint_supported(predict_attr)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "import sys\n",
@@ -27,7 +18,7 @@
     "from lume_model.variables import ScalarVariable\n",
     "from lume_model.models import TorchModel, TorchModule\n",
     "\n",
-    "sys.path.append(\"./calibration_modules/\")\n",
+    "sys.path.append(\"./../../../\")\n",
     "from calibration_modules.decoupled_linear import DecoupledLinearInput\n",
     "from calibration_modules.utils import extract_input_transformer\n",
     "\n",
@@ -125,7 +116,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "🏃 View run learned-horse-949 at: http://127.0.0.1:8082/#/experiments/0/runs/ccc215995faa4e0facf3bc86b1405706\n",
+      "🏃 View run masked-tern-840 at: http://127.0.0.1:8082/#/experiments/0/runs/9d85378ccfac4313b12256a5fa54ad80\n",
       "🧪 View experiment at: http://127.0.0.1:8082/#/experiments/0\n"
      ]
     },
@@ -311,7 +302,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "🏃 View run defiant-doe-411 at: http://127.0.0.1:8082/#/experiments/0/runs/bd856d35d9ef424b8c58bc3e574c4468\n",
+      "🏃 View run welcoming-skink-442 at: http://127.0.0.1:8082/#/experiments/0/runs/003ee83e2a284d3bbad80c6c2e21364c\n",
       "🧪 View experiment at: http://127.0.0.1:8082/#/experiments/0\n"
      ]
     },
@@ -519,8 +510,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 11.2 s, sys: 131 ms, total: 11.3 s\n",
-      "Wall time: 11.3 s\n"
+      "CPU times: user 10.8 s, sys: 124 ms, total: 10.9 s\n",
+      "Wall time: 11 s\n"
      ]
     }
    ],
@@ -871,7 +862,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "🏃 View run overjoyed-crow-564 at: http://127.0.0.1:8082/#/experiments/0/runs/a912a2ea05e942189e5c7ab031fdbaf9\n",
+      "🏃 View run learned-asp-464 at: http://127.0.0.1:8082/#/experiments/0/runs/63a88ed5c60841a3850582f8196c6a9d\n",
       "🧪 View experiment at: http://127.0.0.1:8082/#/experiments/0\n"
      ]
     },
@@ -915,7 +906,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 30,
    "id": "c00e4ab5-f313-4fbe-9c32-0560bd6fde80",
    "metadata": {},
    "outputs": [],
@@ -929,7 +920,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 31,
    "id": "36520ad0-5306-41f9-a2e6-7f507ac7ff23",
    "metadata": {},
    "outputs": [],
@@ -941,7 +932,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 32,
    "id": "9d0318b6-cf58-44ae-8436-63f98b24b446",
    "metadata": {},
    "outputs": [
@@ -951,7 +942,7 @@
        "(-2.2, 0.8)"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     },

--- a/examples/mlflow_integration/gp_model-mlflow.ipynb
+++ b/examples/mlflow_integration/gp_model-mlflow.ipynb
@@ -5,16 +5,7 @@
    "execution_count": 1,
    "id": "0bf3265d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/smiskov/miniconda3/envs/lume-latest/lib/python3.10/site-packages/mlflow/pyfunc/model.py:175: UserWarning: \u001b[31mType hint used in the model's predict function is not supported for MLflow's schema validation. Type hints must be wrapped in list[...] because MLflow assumes the predict method to take multiple input instances. Specify your type hint as `list[typing.Dict[str, typing.Any]]` for a valid signature. Remove the type hint to disable this warning. To enable validation for the input data, specify input example or model signature when logging the model. \u001b[0m\n",
-      "  func_info = _get_func_info_if_type_hint_supported(predict_attr)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "import torch\n",
@@ -229,18 +220,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/smiskov/miniconda3/envs/lume-latest/lib/python3.10/site-packages/mlflow/pyfunc/__init__.py:3153: UserWarning: Failed to infer signature from type hint: Type hints must be wrapped in list[...] because MLflow assumes the predict method to take multiple input instances. Specify your type hint as `list[typing.Dict[str, typing.Any]]` for a valid signature.\n",
-      "  signature_from_type_hints = _infer_signature_from_type_hints(\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "🏃 View run lume-test at: http://127.0.0.1:8082/#/experiments/0/runs/ef9da3ae4bc94d2ea7605e98ff1b5569\n",
+      "🏃 View run lume-test at: http://127.0.0.1:8082/#/experiments/0/runs/5eaf5a2a90434e1bad7b897205f841ad\n",
       "🧪 View experiment at: http://127.0.0.1:8082/#/experiments/0\n"
      ]
     },
@@ -248,8 +231,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Registered model 'lume-model-multi-output-gp' already exists. Creating a new version of this model...\n",
-      "Created version '2' of model 'lume-model-multi-output-gp'.\n"
+      "Successfully registered model 'lume-model-multi-output-gp'.\n",
+      "Created version '1' of model 'lume-model-multi-output-gp'.\n"
      ]
     }
    ],
@@ -354,7 +337,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "🏃 View run lume-test at: http://127.0.0.1:8082/#/experiments/0/runs/ef9da3ae4bc94d2ea7605e98ff1b5569\n",
+      "🏃 View run lume-test at: http://127.0.0.1:8082/#/experiments/0/runs/5eaf5a2a90434e1bad7b897205f841ad\n",
       "🧪 View experiment at: http://127.0.0.1:8082/#/experiments/0\n"
      ]
     }

--- a/lume_model/mlflow_utils.py
+++ b/lume_model/mlflow_utils.py
@@ -1,6 +1,6 @@
 import os
 import warnings
-from typing import Dict, Any, Union
+from typing import Any, Union
 
 from torch import Tensor, nn
 
@@ -159,10 +159,16 @@ class PyFuncModel(mlflow.pyfunc.PythonModel):
     Must implement the `predict` method.
     """
 
+    # Disable type hint validation for the predict method to avoid annoying warnings
+    # since we have type validation in the lume-model itself.
+    # If we need to implement this, this may be helpful:
+    # g
+    _skip_type_hint_validation = True
+
     def __init__(self, model):
         self.model = model
 
-    def predict(self, model_input: Dict[str, Any]) -> Dict[str, Any]:
+    def predict(self, model_input):
         """Evaluate the model with the given input."""
         # Convert input to the format expected by the model
         # TODO: this isn't very general but type validation in torch modules requires this. May need to adjust.


### PR DESCRIPTION
Fixed the issue of type hint warning being shown when importing `mlflow` module, because of missing handling for builtin classes. Also disabled type hint validation for the `pyfunc.PythonModel` since our signature doesn't match what's expected. There may be a workaround for this, but since we have builtin type validation in `lume-model`, it seemed easier to disable this.