### PR TITLE
Migrate from outdated branch-based docs deployment to GHA

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build:
     if: ${{ github.repository == 'slaclab/lume-model' }}
@@ -25,4 +30,18 @@ jobs:
         shell: bash -l {0}
         run: |
           mkdocs build
-          mkdocs gh-deploy --force
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
We will no longer deploy to the `gh-pages` branch, and instead our site contents will be hosted by GitHub