### PR TITLE
Adjust logging to support non-torch custom models

### DIFF
--- a/lume_model/base.py
+++ b/lume_model/base.py
@@ -9,7 +9,6 @@ from io import TextIOWrapper
 import yaml
 import numpy as np
 from pydantic import BaseModel, ConfigDict, field_validator
-import torch  # TODO: for torch.Tensor type hinting, but may need to make more general in mlflow class
 
 from lume_model.variables import ScalarVariable, get_variable, ConfigEnum
 from lume_model.utils import (
@@ -456,7 +455,6 @@ class LUMEBaseModel(BaseModel, ABC):
 
     def register_to_mlflow(
         self,
-        input_dict: dict[str, Union[float, torch.Tensor]],
         artifact_path: str,
         registered_model_name: str | None = None,
         tags: dict[str, Any] | None = None,
@@ -477,7 +475,6 @@ class LUMEBaseModel(BaseModel, ABC):
         https://mlflow.org/docs/latest/getting-started/intro-quickstart/ for more info.
 
         Args:
-            input_dict: Input dictionary to infer the model signature.
             artifact_path: Path to store the model in MLflow.
             registered_model_name: Name of the registered model in MLflow. Optional.
             tags: Tags to add to the MLflow model. Optional.
@@ -493,7 +490,6 @@ class LUMEBaseModel(BaseModel, ABC):
         """
         return register_model(
             self,
-            input_dict,
             artifact_path,
             registered_model_name,
             tags,

--- a/lume_model/models/torch_module.py
+++ b/lume_model/models/torch_module.py
@@ -198,7 +198,6 @@ class TorchModule(torch.nn.Module):
 
     def register_to_mlflow(
         self,
-        input: torch.Tensor,
         artifact_path: str,
         registered_model_name: str | None = None,
         tags: dict[str, Any] | None = None,
@@ -219,7 +218,6 @@ class TorchModule(torch.nn.Module):
         https://mlflow.org/docs/latest/getting-started/intro-quickstart/ for more info.
 
         Args:
-            input: Input tensor to infer the model signature.
             artifact_path: Path to store the model in MLflow.
             registered_model_name: Name of the registered model in MLflow. Optional.
             tags: Tags to add to the MLflow model. Optional.
@@ -235,7 +233,6 @@ class TorchModule(torch.nn.Module):
         """
         return register_model(
             self,
-            input,
             artifact_path,
             registered_model_name,
             tags,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "pydantic",
     "numpy",
     "pyyaml",
+    "torch",
+    "botorch",
     "mlflow"
 ]
 dynamic = ["version"]
@@ -31,12 +33,7 @@ dynamic = ["version"]
 version_file = "lume_model/_version.py"
 
 [project.optional-dependencies]
-torch = [
-    "botorch",
-    "torch"
-]
 dev = [
-    "lume-model[torch]",
     "pre-commit",
     "pytest"
 ]


### PR DESCRIPTION
Closes #126 

The previous implementation of `register_model` only took into account PyTorch based models (as in, only the registered models) and not any custom models that may pass floats and not have .pt dump files. This PR makes that function more general and allows any custom model to be registered.

This PR also removes the need to define a model signature before logging the model. Since we already have clear and robust input/output schema and validation in `lume-model`, I feel like it was just complicating things. So now to register the model, there's no need to pass an input example anymore. 

Additionally, I added `torch` and `botorch` to the base dependencies, since we now depend on `torch` for the `DistributionVariable`. It didn't make sense to split `botorch` to its own option deps option so I moved them together.