### PR TITLE
Refactor

### DIFF
--- a/examples/probabilistic_models/gp_model.ipynb
+++ b/examples/probabilistic_models/gp_model.ipynb
@@ -2,19 +2,26 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "0bf3265d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/smiskov/miniconda3/envs/lume-torch-latest/lib/python3.14/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "import torch\n",
     "from botorch.models import SingleTaskGP\n",
     "from botorch.fit import fit_gpytorch_mll\n",
     "from gpytorch.mlls import ExactMarginalLogLikelihood\n",
     "from lume_torch.variables import TorchScalarVariable, DistributionVariable\n",
-    "from lume_torch.models.gp_model import GPModel\n",
-    "from gpytorch.kernels import RBFKernel\n",
-    "from gpytorch.kernels import ScaleKernel"
+    "from lume_torch.models.gp_model import GPModel"
    ]
   },
   {
@@ -27,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "53eab389-be6f-48a9-9521-c01a0c17a0ee",
    "metadata": {},
    "outputs": [
@@ -36,29 +43,29 @@
      "output_type": "stream",
      "text": [
       "Posterior Mean for each output:\n",
-      "tensor([[ 0.2397,  0.7271,  0.4191],\n",
-      "        [ 0.6916,  0.7995,  1.0390],\n",
-      "        [ 1.0555,  0.1417,  0.3111],\n",
-      "        [ 0.8914, -0.4485, -0.6847],\n",
-      "        [ 0.3121, -0.9120, -0.2559],\n",
-      "        [-0.1309, -0.7975,  0.1390],\n",
-      "        [-0.6172, -0.1708, -0.0208],\n",
-      "        [-0.9243,  0.1479, -0.1613],\n",
-      "        [-0.4698,  0.0957, -0.0618],\n",
-      "        [-0.0174,  0.0082,  0.0473]], dtype=torch.float64,\n",
+      "tensor([[ 0.2057,  1.0192,  0.3797],\n",
+      "        [ 0.6948,  0.7911,  1.0457],\n",
+      "        [ 1.0173,  0.2163,  0.2572],\n",
+      "        [ 0.9157, -0.4811, -0.6407],\n",
+      "        [ 0.3962, -0.9256, -0.1664],\n",
+      "        [-0.2683, -0.8640,  0.0784],\n",
+      "        [-0.7624, -0.3809, -0.0426],\n",
+      "        [-0.9379,  0.1794, -0.1595],\n",
+      "        [-0.8441,  0.5149, -0.0208],\n",
+      "        [-0.6245,  0.5696,  0.0715]], dtype=torch.float64,\n",
       "       grad_fn=<CloneBackward0>)\n",
       "\n",
       "Posterior Variance for each output:\n",
-      "tensor([[0.1171, 0.1131, 0.1045],\n",
-      "        [0.0022, 0.0021, 0.0021],\n",
-      "        [0.0380, 0.0367, 0.0341],\n",
-      "        [0.0156, 0.0150, 0.0140],\n",
-      "        [0.0529, 0.0511, 0.0469],\n",
-      "        [0.0965, 0.0931, 0.0854],\n",
-      "        [0.2123, 0.2048, 0.1875],\n",
-      "        [0.0069, 0.0067, 0.0063],\n",
-      "        [0.3026, 0.2919, 0.2671],\n",
-      "        [0.4321, 0.4169, 0.3814]], dtype=torch.float64,\n",
+      "tensor([[0.0294, 0.0322, 0.2155],\n",
+      "        [0.0015, 0.0014, 0.0026],\n",
+      "        [0.0033, 0.0035, 0.1020],\n",
+      "        [0.0028, 0.0029, 0.0347],\n",
+      "        [0.0028, 0.0030, 0.1173],\n",
+      "        [0.0059, 0.0066, 0.1769],\n",
+      "        [0.0115, 0.0143, 0.3564],\n",
+      "        [0.0034, 0.0033, 0.0091],\n",
+      "        [0.0746, 0.0872, 0.4328],\n",
+      "        [0.2720, 0.2989, 0.5247]], dtype=torch.float64,\n",
       "       grad_fn=<CloneBackward0>)\n"
      ]
     }
@@ -79,13 +86,7 @@
     "\n",
     "\n",
     "# Initialize the GP model\n",
-    "rbf_kernel = ScaleKernel(RBFKernel())\n",
-    "\n",
-    "model = SingleTaskGP(\n",
-    "    train_x.to(dtype=torch.double),\n",
-    "    train_y.to(dtype=torch.double),\n",
-    "    covar_module=rbf_kernel,\n",
-    ")\n",
+    "model = SingleTaskGP(train_x.to(dtype=torch.double), train_y.to(dtype=torch.double))\n",
     "\n",
     "# Fit the model\n",
     "mll = ExactMarginalLogLikelihood(model.likelihood, model)\n",
@@ -115,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "746f7554-d317-400c-9e9b-47cb38422e7c",
    "metadata": {},
    "outputs": [],
@@ -146,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "4b23c0a4-bf07-4351-b6e7-0762346f6e4f",
    "metadata": {},
    "outputs": [],
@@ -156,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "567cc4fb-aa01-40d6-be27-4839eaf23ebb",
    "metadata": {},
    "outputs": [
@@ -175,7 +176,7 @@
        "         [1.0000]], dtype=torch.float64)}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -186,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "a20e922c-22e3-445d-913d-b735ab7c62fc",
    "metadata": {},
    "outputs": [],
@@ -197,7 +198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "2028eda3-7e67-474e-9d71-9d286d3f0749",
    "metadata": {},
    "outputs": [
@@ -209,7 +210,7 @@
        " 'output3': MultivariateNormal(loc: torch.Size([10]), covariance_matrix: torch.Size([10, 10]))}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -220,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "410be85e-8342-4441-b739-3f3f342d1810",
    "metadata": {},
    "outputs": [],
@@ -230,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "77268fda-342b-4319-bc50-2504e9b65817",
    "metadata": {},
    "outputs": [
@@ -238,17 +239,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Posterior mean: tensor([ 0.2397,  0.6916,  1.0555,  0.8914,  0.3121, -0.1309, -0.6172, -0.9243,\n",
-      "        -0.4698, -0.0174], dtype=torch.float64, grad_fn=<ExpandBackward0>)\n",
-      "Posterior Variance  tensor([0.1171, 0.0022, 0.0380, 0.0156, 0.0529, 0.0965, 0.2123, 0.0069, 0.3026,\n",
-      "        0.4321], dtype=torch.float64, grad_fn=<ExpandBackward0>)\n",
-      "Log Likelihood tensor([2.8671, 1.3912], dtype=torch.float64, grad_fn=<SubBackward0>)\n",
-      "Rsample  tensor([[ 0.1371,  0.7029,  0.7924,  0.9986,  0.3675, -0.5925, -1.3643, -0.9383,\n",
-      "         -0.1128,  0.4696],\n",
-      "        [ 0.4477,  0.6424,  0.8958,  0.8927,  0.4303,  0.1575, -0.1585, -0.9204,\n",
-      "         -0.4836,  0.2818],\n",
-      "        [ 0.6743,  0.6468,  0.9740,  0.9098,  0.3655, -0.4459, -1.5865, -0.8818,\n",
-      "         -0.3347, -0.3025]], dtype=torch.float64, grad_fn=<ViewBackward0>)\n"
+      "Posterior mean: tensor([ 0.2057,  0.6948,  1.0173,  0.9157,  0.3962, -0.2683, -0.7624, -0.9379,\n",
+      "        -0.8441, -0.6245], dtype=torch.float64, grad_fn=<ExpandBackward0>)\n",
+      "Posterior Variance  tensor([0.0294, 0.0015, 0.0033, 0.0028, 0.0028, 0.0059, 0.0115, 0.0034, 0.0746,\n",
+      "        0.2720], dtype=torch.float64, grad_fn=<ExpandBackward0>)\n",
+      "Log Likelihood tensor([17.3171, 15.8412], dtype=torch.float64, grad_fn=<SubBackward0>)\n",
+      "Rsample  tensor([[ 0.1544,  0.7000,  0.9810,  0.8623,  0.3631, -0.3833, -0.9663, -0.9788,\n",
+      "         -0.4930,  0.0778],\n",
+      "        [ 0.3099,  0.6627,  0.9307,  0.8558,  0.4026, -0.1392, -0.5748, -0.9376,\n",
+      "         -1.1807, -1.1273],\n",
+      "        [ 0.4233,  0.6754,  0.9243,  0.8847,  0.4144, -0.3218, -0.9260, -1.0431,\n",
+      "         -0.7037, -0.3066]], dtype=torch.float64, grad_fn=<ViewBackward0>)\n"
      ]
     }
    ],
@@ -269,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "c9883480-f8fd-4899-8417-a8e041da0204",
    "metadata": {},
    "outputs": [
@@ -277,10 +278,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Posterior mean: tensor([ 0.2397,  0.6916,  1.0555,  0.8914,  0.3121, -0.1309, -0.6172, -0.9243,\n",
-      "        -0.4698, -0.0174], dtype=torch.float64, grad_fn=<SelectBackward0>)\n",
-      "Posterior Variance  tensor([0.1171, 0.0022, 0.0380, 0.0156, 0.0529, 0.0965, 0.2123, 0.0069, 0.3026,\n",
-      "        0.4321], dtype=torch.float64, grad_fn=<SelectBackward0>)\n"
+      "Posterior mean: tensor([ 0.2057,  0.6948,  1.0173,  0.9157,  0.3962, -0.2683, -0.7624, -0.9379,\n",
+      "        -0.8441, -0.6245], dtype=torch.float64, grad_fn=<SelectBackward0>)\n",
+      "Posterior Variance  tensor([0.0294, 0.0015, 0.0033, 0.0028, 0.0028, 0.0059, 0.0115, 0.0034, 0.0746,\n",
+      "        0.2720], dtype=torch.float64, grad_fn=<SelectBackward0>)\n"
      ]
     }
    ],
@@ -307,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "8e1caf84-00be-414d-a9b6-9d4f846290e9",
    "metadata": {},
    "outputs": [],
@@ -325,7 +326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "e9ed72c5-3256-4b17-9713-54d2eb46dac9",
    "metadata": {},
    "outputs": [
@@ -359,7 +360,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/smiskov/miniconda3/envs/lume-torch-latest/lib/python3.14/site-packages/botorch/models/utils/assorted.py:271: InputDataWarning: Data (input features) is not contained to the unit cube. Please consider min-max scaling the input data.\n",
+      "/Users/smiskov/miniconda3/envs/lume-torch-latest/lib/python3.14/site-packages/botorch/models/utils/assorted.py:276: InputDataWarning: Data (input features) is not contained to the unit cube. Please consider min-max scaling the input data.\n",
       "  check_min_max_scaling(\n"
      ]
     }
@@ -399,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "d256cedf",
    "metadata": {},
    "outputs": [],
@@ -430,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "d8e61307-8ff8-45ea-8ea1-d2a846e3beaa",
    "metadata": {},
    "outputs": [],
@@ -445,7 +446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "eb69c88b-a94d-4c0b-bee8-2ae0b40a3577",
    "metadata": {},
    "outputs": [],
@@ -456,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "id": "424760a2-2626-4c60-a7db-9baaf1b60084",
    "metadata": {},
    "outputs": [],
@@ -466,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "id": "f9c4f8d8-da8e-44d2-b18c-53fb6f75897a",
    "metadata": {},
    "outputs": [
@@ -503,7 +504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "id": "fd60e0f6-9e0e-47e0-8fa5-82b97778375b",
    "metadata": {},
    "outputs": [],
@@ -514,7 +515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "id": "1d0254a6-6059-420c-9184-ca8bc4b464d2",
    "metadata": {},
    "outputs": [

--- a/lume_torch/base.py
+++ b/lume_torch/base.py
@@ -9,7 +9,7 @@ from io import TextIOWrapper
 import yaml
 import torch
 import numpy as np
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 from lume_torch.variables import (
     TorchScalarVariable,
@@ -424,7 +424,8 @@ class LUMETorch(BaseModel, ABC):
             for name, val in value.items():
                 if isinstance(val, dict):
                     variable_class = get_variable(val["variable_class"])
-                    new_value.append(variable_class(name=name, **val))
+                    val_kwargs = {k: v for k, v in val.items() if k != "variable_class"}
+                    new_value.append(variable_class(name=name, **val_kwargs))
                 elif isinstance(
                     val,
                     (
@@ -485,6 +486,33 @@ class LUMETorch(BaseModel, ABC):
         verify_unique_variable_names(value)
         return value
 
+    @field_validator(
+        "input_validation_config", "output_validation_config", mode="before"
+    )
+    @classmethod
+    def _check_validation_config_is_dict(cls, value):
+        # Let pydantic handle type errors; only dicts need key checks (done in model_validator)
+        return value
+
+    @model_validator(mode="after")
+    def _check_validation_config_keys(self):
+        """Raise if any key in input_/output_validation_config is not a known variable name."""
+        if self.input_validation_config is not None:
+            invalid = set(self.input_validation_config) - set(self.input_names)
+            if invalid:
+                raise ValueError(
+                    f"input_validation_config contains unknown variable name(s): "
+                    f"{sorted(invalid)}. Valid input names: {sorted(self.input_names)}"
+                )
+        if self.output_validation_config is not None:
+            invalid = set(self.output_validation_config) - set(self.output_names)
+            if invalid:
+                raise ValueError(
+                    f"output_validation_config contains unknown variable name(s): "
+                    f"{sorted(invalid)}. Valid output names: {sorted(self.output_names)}"
+                )
+        return self
+
     @property
     def input_names(self) -> list[str]:
         return [var.name for var in self.input_variables]
@@ -511,7 +539,7 @@ class LUMETorch(BaseModel, ABC):
         Validates that the keys in the input dictionary are a subset of the valid variable names.
         """
         valid_keys = self.input_names if dict_name == "input" else self.output_names
-        valid_names = {name for name in valid_keys}
+        valid_names = set(valid_keys)
         invalid_keys = set(in_dict.keys()) - valid_names
         if invalid_keys:
             raise ValueError(

--- a/lume_torch/base.py
+++ b/lume_torch/base.py
@@ -493,18 +493,6 @@ class LUMETorch(BaseModel, ABC):
     def output_names(self) -> list[str]:
         return [var.name for var in self.output_variables]
 
-    @property
-    def default_input_validation_config(self) -> dict[str, ConfigEnum]:
-        """Determines default behavior during input validation (if input_validation_config is None)."""
-        return {var.name: var.default_validation_config for var in self.input_variables}
-
-    @property
-    def default_output_validation_config(self) -> dict[str, ConfigEnum]:
-        """Determines default behavior during output validation (if output_validation_config is None)."""
-        return {
-            var.name: var.default_validation_config for var in self.output_variables
-        }
-
     def evaluate(self, input_dict: dict[str, Any], **kwargs) -> dict[str, Any]:
         """Main evaluation function, child classes must implement the _evaluate method."""
         self._validate_dict_keys(input_dict, dict_name="input")
@@ -531,13 +519,22 @@ class LUMETorch(BaseModel, ABC):
                 f"Valid variables are: {sorted(valid_names)}"
             )
 
-    def input_validation(self, input_dict: dict[str, Any]) -> dict[str, Any]:
+    def input_validation(
+        self,
+        input_dict: dict[str, Any],
+        check_read_only: bool = False,
+        check_no_missing_inputs=False,
+    ) -> dict[str, Any]:
         """Validates input dictionary values against input variable specifications.
 
         Parameters
         ----------
         input_dict : dict of str to Any
             Dictionary of input variable names to values.
+        check_read_only : bool, optional
+            Whether to check that read-only variables match their default values, by default False.
+        check_no_missing_inputs : bool, optional
+            Whether to check for missing inputs, by default False.
 
         Returns
         -------
@@ -545,14 +542,28 @@ class LUMETorch(BaseModel, ABC):
             Validated input dictionary.
 
         """
-        for name, value in input_dict.items():
-            _config = (
+        # type/dtype check on raw user-provided values (before tensor conversion)
+        for var in self.input_variables:
+            config = (
                 None
                 if self.input_validation_config is None
-                else self.input_validation_config.get(name)
+                or var.name not in self.input_validation_config
+                else self.input_validation_config.get(var.name, None)
             )
-            var = self.input_variables[self.input_names.index(name)]
-            var.validate_value(value, config=_config)
+            if var.name in input_dict:
+                if var.read_only and check_read_only:
+                    # TODO: do we need both here?
+                    var.validate_value(var.default_value, config=config)
+                    var.validate_read_only(input_dict[var.name], config=config)
+                else:
+                    var.validate_value(input_dict[var.name], config=config)
+            elif var.name not in input_dict and check_no_missing_inputs:
+                raise ValueError(
+                    f"Missing required input variable '{var.name}' in input_dict."
+                )
+            else:
+                # check all other default values in case of dynamic changes to defaults
+                var.validate_value(var.default_value, config=config)
 
         return input_dict
 
@@ -579,7 +590,7 @@ class LUMETorch(BaseModel, ABC):
             _config = (
                 None
                 if self.output_validation_config is None
-                else self.output_validation_config.get(name)
+                else self.output_validation_config.get(name, None)
             )
             var = self.output_variables[self.output_names.index(name)]
             var.validate_value(value, config=_config)

--- a/lume_torch/base.py
+++ b/lume_torch/base.py
@@ -9,7 +9,7 @@ from io import TextIOWrapper
 import yaml
 import torch
 import numpy as np
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from lume_torch.variables import (
     TorchScalarVariable,
@@ -363,6 +363,12 @@ class LUMETorch(BaseModel, ABC):
     output_validation_config : dict of str to ConfigEnum, optional
         Determines the behavior during output validation by specifying the validation
         config for each output variable: {var_name: value}. Value can be "warn", "error", or "none".
+    require_all_inputs : bool
+        When ``True``, :meth:`input_validation` raises ``ValueError`` for any
+        input variable absent from the dictionary.  When ``False`` (the
+        default), absent inputs fall back to their ``default_value``.
+        Subclasses such as ``ProbabilisticBaseModel`` override this to
+        ``True``.
 
     Methods
     -------
@@ -396,6 +402,15 @@ class LUMETorch(BaseModel, ABC):
     ]
     input_validation_config: Optional[dict[str, ConfigEnum]] = None
     output_validation_config: Optional[dict[str, ConfigEnum]] = None
+    require_all_inputs: bool = Field(
+        default=False,
+        exclude=True,
+        description=(
+            "When True, input_validation raises if any input variable is "
+            "absent from the provided dictionary.  Subclasses (e.g. "
+            "ProbabilisticBaseModel) may override the default."
+        ),
+    )
 
     model_config = ConfigDict(arbitrary_types_allowed=True, validate_assignment=True)
 
@@ -550,19 +565,25 @@ class LUMETorch(BaseModel, ABC):
     def input_validation(
         self,
         input_dict: dict[str, Any],
-        check_read_only: bool = False,
-        check_no_missing_inputs=False,
     ) -> dict[str, Any]:
         """Validates input dictionary values against input variable specifications.
+
+        Read-only enforcement is unconditional: if a variable has
+        ``read_only=True``, the provided value is always checked against
+        the default.  Use the per-variable ``ConfigEnum`` (via
+        ``input_validation_config``) to control strictness (error / warn /
+        none).
+
+        Missing-input behaviour is controlled by the class-level attribute
+        ``require_all_inputs``.  When ``True`` (e.g. in
+        ``ProbabilisticBaseModel``), a ``ValueError`` is raised for any
+        absent input.  When ``False`` (the default), absent inputs fall
+        back to their ``default_value``.
 
         Parameters
         ----------
         input_dict : dict of str to Any
             Dictionary of input variable names to values.
-        check_read_only : bool, optional
-            Whether to check that read-only variables match their default values, by default False.
-        check_no_missing_inputs : bool, optional
-            Whether to check for missing inputs, by default False.
 
         Returns
         -------
@@ -579,7 +600,7 @@ class LUMETorch(BaseModel, ABC):
                 else self.input_validation_config.get(var.name, None)
             )
             if var.name in input_dict:
-                if var.read_only and check_read_only:
+                if var.read_only and var.default_value is not None:
                     # Validates that the default value is valid
                     # and then checks that the provided value matches the default value
                     # for read-only variables *for all samples in a batch*
@@ -587,7 +608,7 @@ class LUMETorch(BaseModel, ABC):
                     var.validate_read_only(input_dict[var.name], config=config)
                 else:
                     var.validate_value(input_dict[var.name], config=config)
-            elif var.name not in input_dict and check_no_missing_inputs:
+            elif self.require_all_inputs:
                 raise ValueError(
                     f"Missing required input variable '{var.name}' in input_dict."
                 )
@@ -603,6 +624,9 @@ class LUMETorch(BaseModel, ABC):
 
     def output_validation(self, output_dict: dict[str, Any]) -> dict[str, Any]:
         """Validates output dictionary values against output variable specifications.
+
+        Read-only enforcement is unconditional: if an output variable has
+        ``read_only=True``, the produced value is checked against the default.
 
         Parameters
         ----------
@@ -627,7 +651,11 @@ class LUMETorch(BaseModel, ABC):
                 else self.output_validation_config.get(name, None)
             )
             var = self.output_variables[self.output_names.index(name)]
-            var.validate_value(value, config=_config)
+            if var.read_only and var.default_value is not None:
+                var.validate_value(var.default_value, config=_config)
+                var.validate_read_only(value, config=_config)
+            else:
+                var.validate_value(value, config=_config)
         return output_dict
 
     def to_json(self, **kwargs) -> str:

--- a/lume_torch/base.py
+++ b/lume_torch/base.py
@@ -552,7 +552,9 @@ class LUMETorch(BaseModel, ABC):
             )
             if var.name in input_dict:
                 if var.read_only and check_read_only:
-                    # TODO: do we need both here?
+                    # Validates that the default value is valid
+                    # and then checks that the provided value matches the default value
+                    # for read-only variables *for all samples in a batch*
                     var.validate_value(var.default_value, config=config)
                     var.validate_read_only(input_dict[var.name], config=config)
                 else:

--- a/lume_torch/base.py
+++ b/lume_torch/base.py
@@ -563,6 +563,10 @@ class LUMETorch(BaseModel, ABC):
                 )
             else:
                 # check all other default values in case of dynamic changes to defaults
+                if var.default_value is None:
+                    raise ValueError(
+                        f"Input variable '{var.name}' is missing from input_dict and has no default value."
+                    )
                 var.validate_value(var.default_value, config=config)
 
         return input_dict

--- a/lume_torch/base.py
+++ b/lume_torch/base.py
@@ -600,7 +600,12 @@ class LUMETorch(BaseModel, ABC):
                 else self.input_validation_config.get(var.name, None)
             )
             if var.name in input_dict:
-                if var.read_only and var.default_value is not None:
+                if var.read_only:
+                    if var.default_value is None:
+                        raise ValueError(
+                            f"Input variable '{var.name}' is read-only but has "
+                            f"no default value to validate against."
+                        )
                     # Validates that the default value is valid
                     # and then checks that the provided value matches the default value
                     # for read-only variables *for all samples in a batch*

--- a/lume_torch/models/prob_model_base.py
+++ b/lume_torch/models/prob_model_base.py
@@ -171,7 +171,10 @@ class ProbabilisticBaseModel(LUMETorch):
             Dictionary mapping output variable names to predictive distributions.
 
         """
-        return self._get_predictions(input_dict, **kwargs)
+        formatted_input_dict = format_inputs(
+            input_dict, tensor_kwargs=self._tkwargs, squeeze=True
+        )
+        return self._get_predictions(formatted_input_dict, **kwargs)
 
     @abstractmethod
     def _get_predictions(
@@ -210,46 +213,7 @@ class ProbabilisticBaseModel(LUMETorch):
             Validated input dictionary.
 
         """
-        # type/dtype check on raw user-provided values (before tensor conversion)
-        for var in self.input_variables:
-            config = (
-                None
-                if self.input_validation_config is None
-                else self.input_validation_config[var.name]
-            )
-            if var.name not in input_dict:
-                raise ValueError(
-                    f"Missing required input variable '{var.name}' in input_dict."
-                )
-            var.validate_value(input_dict[var.name], config=config)
-
-        # format inputs as tensors w/o changing the dtype
-        formatted_inputs = format_inputs(input_dict.copy())
-
-        # cast tensors to expected dtype and device
-        formatted_inputs = {
-            k: v.to(**self._tkwargs).squeeze(-1) for k, v in formatted_inputs.items()
-        }
-
-        return formatted_inputs
-
-    def output_validation(self, output_dict: dict[str, TDistribution]):
-        """Validates output distributions against output variable specifications.
-
-        Parameters
-        ----------
-        output_dict : dict of str to TDistribution
-            Output dictionary to validate.
-
-        """
-        for var in self.output_variables:
-            config = (
-                None
-                if self.output_validation_config is None
-                else self.output_validation_config[var.name]
-            )
-            if var.name in output_dict:
-                var.validate_value(output_dict[var.name], config=config)
+        return super().input_validation(input_dict, check_no_missing_inputs=True)
 
 
 class TorchDistributionWrapper(TDistribution):

--- a/lume_torch/models/prob_model_base.py
+++ b/lume_torch/models/prob_model_base.py
@@ -40,10 +40,6 @@ class ProbabilisticBaseModel(LUMETorch):
         Evaluates the model by calling :meth:`_get_predictions`.
     _get_predictions(input_dict, **kwargs)
         Abstract method that returns a dictionary of output distributions.
-    input_validation(input_dict)
-        Validates and normalizes the input dictionary prior to evaluation.
-    output_validation(output_dict)
-        Validates the output dictionary of distributions.
 
     Notes
     -----
@@ -56,6 +52,7 @@ class ProbabilisticBaseModel(LUMETorch):
     output_variables: list[DistributionVariable]
     device: Union[torch.device, str] = "cpu"
     precision: str = "double"
+    require_all_inputs: bool = True
 
     @model_validator(mode="before")
     def validate_output_variables(cls, values: dict[str, Any]) -> dict[str, Any]:
@@ -198,22 +195,6 @@ class ProbabilisticBaseModel(LUMETorch):
 
         """
         pass
-
-    def input_validation(self, input_dict: dict[str, Union[float, torch.Tensor]]):
-        """Validates input dictionary before evaluation.
-
-        Parameters
-        ----------
-        input_dict : dict of str to float or torch.Tensor
-            Input dictionary to validate.
-
-        Returns
-        -------
-        dict of str to float or torch.Tensor
-            Validated input dictionary.
-
-        """
-        return super().input_validation(input_dict, check_no_missing_inputs=True)
 
 
 class TorchDistributionWrapper(TDistribution):

--- a/lume_torch/models/torch_model.py
+++ b/lume_torch/models/torch_model.py
@@ -683,14 +683,13 @@ class TorchModel(LUMETorch):
             Tensor of transformed inputs to be passed to the model.
 
         """
-        # Make at least 2D
-        if input_tensor.ndim == 0:
-            input_tensor = input_tensor.unsqueeze(0)
-        if input_tensor.ndim == 1:
-            input_tensor = input_tensor.unsqueeze(0)
-
         for transformer in self.input_transformers:
             if isinstance(transformer, ReversibleInputTransform):
+                # Make at least 2D for botorch transforms, which expect (batch, features)
+                if input_tensor.ndim == 0:
+                    input_tensor = input_tensor.unsqueeze(0)
+                if input_tensor.ndim == 1:
+                    input_tensor = input_tensor.unsqueeze(0)
                 input_tensor = transformer.transform(input_tensor)
             else:
                 input_tensor = transformer(input_tensor)
@@ -770,17 +769,11 @@ class TorchModel(LUMETorch):
                     # Shape is (batch,), reshape to (batch, 1)
                     parsed_outputs[self.output_names[0]] = output.unsqueeze(-1)
                 else:
-                    # 3D or higher dimensional - squeeze last dim if it's 1
-                    # This handles multi-sample cases: (batch, samples, 1) -> (batch, samples)
+                    # 3D or higher: preserve all batch/sample dims, ensure last dim is 1
                     if output.shape[-1] != 1:
                         parsed_outputs[self.output_names[0]] = output.unsqueeze(-1)
                     else:
-                        # Shouldn't happen, but handle by squeezing all and adding feature dim
-                        parsed_outputs[self.output_names[0]] = (
-                            output.squeeze().unsqueeze(-1)
-                            if output.squeeze().dim() > 0
-                            else output.squeeze().unsqueeze(0).unsqueeze(-1)
-                        )
+                        parsed_outputs[self.output_names[0]] = output
             else:
                 # For non-scalar outputs (NDVariable), keep original behavior
                 parsed_outputs[self.output_names[0]] = output.squeeze()
@@ -798,12 +791,8 @@ class TorchModel(LUMETorch):
                         # Scalar output, reshape to (1, 1)
                         parsed_outputs[output_name] = output.unsqueeze(0).unsqueeze(-1)
                     else:
-                        # Already has proper dimensions or higher, ensure last dim is 1
-                        parsed_outputs[output_name] = (
-                            output.squeeze().unsqueeze(-1)
-                            if output.squeeze().dim() > 0
-                            else output.squeeze().unsqueeze(0).unsqueeze(-1)
-                        )
+                        # 2D+ (e.g. batch, samples): add feature dim
+                        parsed_outputs[output_name] = output.unsqueeze(-1)
                 else:
                     # For non-scalar outputs (NDVariable), keep original behavior
                     parsed_outputs[output_name] = output.squeeze()

--- a/lume_torch/models/torch_model.py
+++ b/lume_torch/models/torch_model.py
@@ -609,12 +609,25 @@ class TorchModel(LUMETorch):
                 if batch_shape is None:
                     batch_shape = current_batch
                 elif current_batch != batch_shape:
-                    raise ValueError(
-                        f"Inputs have inconsistent batch shapes: "
-                        f"{batch_shape} vs {current_batch}"
-                    )
+                    # Allow singleton batch to broadcast
+                    if current_batch == torch.Size([1]):
+                        value = value.expand(*batch_shape, *value.shape[1:])
+                    elif batch_shape == torch.Size([1]):
+                        batch_shape = current_batch
+                    else:
+                        raise ValueError(
+                            f"Inputs have inconsistent batch shapes: "
+                            f"{batch_shape} vs {current_batch}"
+                        )
 
                 tensor_list.append(value.to(**self._tkwargs))
+
+            # Expand any earlier singleton-batch tensors to the final batch_shape
+            if batch_shape != torch.Size([1]):
+                tensor_list = [
+                    t.expand(*batch_shape, *t.shape[1:]) if t.shape[0] == 1 else t
+                    for t in tensor_list
+                ]
 
             stacked = torch.stack(tensor_list, dim=1)  # (batch, num_arrays, ...)
             logger.debug(f"Arranged ND inputs into tensor shape: {stacked.shape}")

--- a/lume_torch/models/torch_model.py
+++ b/lume_torch/models/torch_model.py
@@ -49,10 +49,6 @@ class TorchModel(LUMETorch):
     -------
     evaluate(input_dict, **kwargs)
         Evaluate the model on a dictionary of inputs and return outputs.
-    input_validation(input_dict)
-        Validate and normalize the input dictionary before evaluation.
-    output_validation(output_dict)
-        Validate the output dictionary after evaluation.
     random_input(n_samples=1)
         Generate random inputs consistent with the input variable ranges.
     random_evaluate(n_samples=1)
@@ -321,22 +317,6 @@ class TorchModel(LUMETorch):
         parsed_outputs = self._parse_outputs(output_tensor)
         output_dict = self._prepare_outputs(parsed_outputs)
         return output_dict
-
-    def input_validation(self, input_dict: dict[str, Union[float, torch.Tensor]]):
-        """Validate the input dictionary before evaluation.
-
-        Parameters
-        ----------
-        input_dict : dict of str to float or torch.Tensor
-            Input dictionary to validate.
-
-        Returns
-        -------
-        dict of str to float or torch.Tensor
-            Validated input dictionary.
-
-        """
-        return super().input_validation(input_dict, check_read_only=True)
 
     def random_input(self, n_samples: int = 1) -> dict[str, torch.Tensor]:
         """Generates random input(s) for the model.

--- a/lume_torch/models/torch_model.py
+++ b/lume_torch/models/torch_model.py
@@ -313,7 +313,7 @@ class TorchModel(LUMETorch):
             Dictionary of output variable names to values.
 
         """
-        formatted_inputs = format_inputs(input_dict)
+        formatted_inputs = format_inputs(input_dict, tensor_kwargs=self._tkwargs)
         input_tensor = self._arrange_inputs(formatted_inputs)
         input_tensor = self._transform_inputs(input_tensor)
         output_tensor = self.model(input_tensor)
@@ -336,53 +336,7 @@ class TorchModel(LUMETorch):
             Validated input dictionary.
 
         """
-        # type/dtype check on raw user-provided values (before tensor conversion)
-        for var in self.input_variables:
-            config = (
-                None
-                if self.input_validation_config is None
-                or var.name not in self.input_validation_config
-                else self.input_validation_config[var.name]
-            )
-            if var.name in input_dict:
-                if var.read_only:
-                    var.validate_value(var.default_value, config=config)
-                    var.validate_read_only(input_dict[var.name], config=config)
-                else:
-                    var.validate_value(input_dict[var.name], config=config)
-            else:
-                # check all other default values in case of dynamic changes to defaults
-                var.validate_value(var.default_value, config=config)
-
-        # format inputs as tensors w/o changing the dtype
-        formatted_inputs = format_inputs(input_dict)
-
-        # cast tensors to expected dtype and device
-        formatted_inputs = {
-            k: v.to(**self._tkwargs) for k, v in formatted_inputs.items()
-        }
-
-        return formatted_inputs
-
-    def output_validation(self, output_dict: dict[str, Union[float, torch.Tensor]]):
-        """Validate the output dictionary after evaluation.
-
-        Parameters
-        ----------
-        output_dict : dict of str to float or torch.Tensor
-            Output dictionary to validate.
-
-        """
-        for var in self.output_variables:
-            config = (
-                None
-                if self.output_validation_config is None
-                or var.name not in self.output_validation_config
-                or self.output_validation_config[var.name] is None
-                else self.output_validation_config[var.name]
-            )
-            if var.name in output_dict:
-                var.validate_value(output_dict[var.name], config=config)
+        return super().input_validation(input_dict, check_read_only=True)
 
     def random_input(self, n_samples: int = 1) -> dict[str, torch.Tensor]:
         """Generates random input(s) for the model.

--- a/lume_torch/models/torch_model.py
+++ b/lume_torch/models/torch_model.py
@@ -621,52 +621,56 @@ class TorchModel(LUMETorch):
             return stacked
 
         # All TorchScalarVariables
-        default_list = []
+        defaults = torch.stack(
+            [
+                self._default_to_tensor(var.default_value).reshape(())
+                for var in self.input_variables
+            ]
+        ).to(**self._tkwargs)  # shape: (num_inputs,)
+
+        if not formatted_inputs:
+            return defaults.unsqueeze(0)  # (1, num_inputs)
+
+        # Determine batch shape and validate consistency across all provided inputs
+        batch_shape = None
         for var in self.input_variables:
-            default_list.append(self._default_to_tensor(var.default_value))
-
-        default_tensor = torch.cat([d.flatten() for d in default_list]).to(
-            **self._tkwargs
-        )
-
-        if formatted_inputs:
-            batch_shape = None
-            for var in self.input_variables:
-                if var.name in formatted_inputs:
-                    value = formatted_inputs[var.name]
-                    if value.ndim > 0 and value.shape[-1] in (0, 1):
-                        batch_shape = value.shape[:-1]
-                    else:
-                        batch_shape = value.shape
-                    break
-
-            if batch_shape and len(batch_shape) > 0:
-                expanded_shape = (*batch_shape, default_tensor.shape[0])
-                input_tensor = (
-                    default_tensor.unsqueeze(0).expand(expanded_shape).clone()
-                )
+            if var.name not in formatted_inputs:
+                continue
+            value = formatted_inputs[var.name]
+            if value.ndim == 0:
+                current_batch = torch.Size([])
+            elif value.ndim == 1:
+                current_batch = value.shape  # (batch,)
             else:
-                input_tensor = default_tensor.unsqueeze(0)
+                # (..., 1) — strip trailing feature dim
+                if value.shape[-1] != 1:
+                    raise ValueError(
+                        f"Scalar input '{var.name}' has unexpected shape {value.shape}; "
+                        f"expected 0D, 1D, or (..., 1)."
+                    )
+                current_batch = value.shape[:-1]
 
-            current_idx = 0
-            for var in self.input_variables:
-                if var.name in formatted_inputs:
-                    value = formatted_inputs[var.name]
-                    if value.ndim > 0 and value.shape[-1] == 1:
-                        input_tensor[..., current_idx] = value.squeeze(-1)
-                    else:
-                        input_tensor[..., current_idx] = value
-                current_idx += 1
+            if batch_shape is None:
+                batch_shape = current_batch
+            elif current_batch != batch_shape:
+                raise ValueError(
+                    f"Inconsistent batch shapes across scalar inputs: "
+                    f"{batch_shape} vs {current_batch} for '{var.name}'"
+                )
+
+        if batch_shape:
+            input_tensor = defaults.unsqueeze(0).expand(*batch_shape, -1).clone()
         else:
-            input_tensor = default_tensor.unsqueeze(0)
+            input_tensor = defaults.unsqueeze(0)  # (1, num_inputs)
 
-        expected_features = len(self.input_variables)
-        if input_tensor.shape[-1] != expected_features:
-            raise ValueError(
-                "Last dimension of input tensor doesn't match the expected number of features\n"
-                f"received: {input_tensor.shape}, expected {expected_features} as the last dimension"
-            )
+        for idx, var in enumerate(self.input_variables):
+            if var.name in formatted_inputs:
+                value = formatted_inputs[var.name].to(**self._tkwargs)
+                if value.ndim > 1 and value.shape[-1] == 1:
+                    value = value.squeeze(-1)
+                input_tensor[..., idx] = value
 
+        logger.debug(f"Arranged scalar inputs into tensor shape: {input_tensor.shape}")
         return input_tensor
 
     def _transform_inputs(self, input_tensor: torch.Tensor) -> torch.Tensor:
@@ -736,66 +740,40 @@ class TorchModel(LUMETorch):
         """
         parsed_outputs = {}
 
-        # Check if all outputs are scalar variables
         all_scalars = all(
             isinstance(v, TorchScalarVariable) for v in self.output_variables
         )
 
-        # Handle 0D and 1D tensors
+        # Normalize to at least 2D: (batch, features)
         if output_tensor.dim() == 0:
-            # 0D tensor - always add batch dimension at start
-            output_tensor = output_tensor.unsqueeze(0)
+            output_tensor = output_tensor.reshape(1, 1)
         elif output_tensor.dim() == 1:
-            # 1D tensor - interpretation depends on variable types
             if all_scalars and len(self.output_names) == 1:
-                # For single scalar output, 1D means (batch,) -> should become (batch, 1)
+                # (batch,) → (batch, 1)
                 output_tensor = output_tensor.unsqueeze(-1)
-            elif all_scalars and len(self.output_names) > 1:
-                # For multiple scalar outputs, 1D means (features,) -> should become (1, features)
-                output_tensor = output_tensor.unsqueeze(0)
             else:
-                # For non-scalar outputs, default to adding batch dimension at start
+                # (features,) → (1, features)
                 output_tensor = output_tensor.unsqueeze(0)
 
         if len(self.output_names) == 1:
-            output = output_tensor
-            # For scalar variables, ensure shape is (batch, 1) for single-sample batched outputs
-            # or (batch, samples) for multi-sample outputs
             if all_scalars:
-                if output.dim() == 2:
-                    # Already 2D: could be (batch, 1) or (batch, samples) - keep as is
-                    parsed_outputs[self.output_names[0]] = output
-                elif output.dim() == 1:
-                    # Shape is (batch,), reshape to (batch, 1)
-                    parsed_outputs[self.output_names[0]] = output.unsqueeze(-1)
-                else:
-                    # 3D or higher: preserve all batch/sample dims, ensure last dim is 1
-                    if output.shape[-1] != 1:
-                        parsed_outputs[self.output_names[0]] = output.unsqueeze(-1)
-                    else:
-                        parsed_outputs[self.output_names[0]] = output
+                # Scalar: keep full tensor, shape is (*batch, 1) or (*batch, features)
+                parsed_outputs[self.output_names[0]] = output_tensor
             else:
-                # For non-scalar outputs (NDVariable), keep original behavior
-                parsed_outputs[self.output_names[0]] = output.squeeze()
+                # ND: model returns (batch, num_outputs, *array_shape);
+                # remove the num_outputs dim (dim 1) for single-output models
+                # so _dictionary_to_tensor can re-stack along dim 1.
+                parsed_outputs[self.output_names[0]] = output_tensor.squeeze(1)
         else:
             for idx, output_name in enumerate(self.output_names):
                 output = output_tensor[..., idx]
                 var = self.output_variables[idx]
 
-                # For scalar variables, ensure shape is (batch, 1) for batched outputs
                 if isinstance(var, TorchScalarVariable):
-                    if output.dim() == 1:
-                        # Shape is (batch,), reshape to (batch, 1)
-                        parsed_outputs[output_name] = output.unsqueeze(-1)
-                    elif output.dim() == 0:
-                        # Scalar output, reshape to (1, 1)
-                        parsed_outputs[output_name] = output.unsqueeze(0).unsqueeze(-1)
-                    else:
-                        # 2D+ (e.g. batch, samples): add feature dim
-                        parsed_outputs[output_name] = output.unsqueeze(-1)
+                    # Ensure trailing feature dim: (*batch,) → (*batch, 1)
+                    parsed_outputs[output_name] = output.unsqueeze(-1)
                 else:
-                    # For non-scalar outputs (NDVariable), keep original behavior
-                    parsed_outputs[output_name] = output.squeeze()
+                    parsed_outputs[output_name] = output
 
         return parsed_outputs
 

--- a/lume_torch/models/torch_module.py
+++ b/lume_torch/models/torch_module.py
@@ -72,6 +72,12 @@ class TorchModule(torch.nn.Module):
             )
         else:
             logger.debug(f"Initializing TorchModule with model: {type(model).__name__}")
+            if model.output_format != "tensor":
+                logger.warning(
+                    f"TorchModule requires output_format='tensor', "
+                    f"but got '{model.output_format}'. Switching to 'tensor'."
+                )
+                model.output_format = "tensor"
             self._model = model
             self._input_order = input_order
             self._output_order = output_order
@@ -116,8 +122,9 @@ class TorchModule(torch.nn.Module):
         model_input = self._tensor_to_dictionary(x)
         y_model = self.evaluate_model(model_input)
         y_model = self.manipulate_output(y_model)
-        # squeeze for use as prior mean in botorch GPs
-        y = self._dictionary_to_tensor(y_model).squeeze()
+        # squeeze trailing output-feature dim (K=1) for BoTorch Mean compatibility,
+        # but preserve all batch/sample dimensions
+        y = self._dictionary_to_tensor(y_model).squeeze(-1)
         return y
 
     def yaml(

--- a/lume_torch/models/torch_module.py
+++ b/lume_torch/models/torch_module.py
@@ -10,6 +10,7 @@ import torch
 from lume_torch.base import parse_config, recursive_serialize
 from lume_torch.models.torch_model import TorchModel
 from lume_torch.mlflow_utils import register_model
+from lume_torch.variables import TorchScalarVariable, TorchNDVariable
 
 logger = logging.getLogger(__name__)
 
@@ -116,15 +117,40 @@ class TorchModule(torch.nn.Module):
         else:
             return self._output_order
 
+    @property
+    def _nd_inputs(self) -> bool:
+        """True when every input variable is a TorchNDVariable."""
+        return all(isinstance(v, TorchNDVariable) for v in self._model.input_variables)
+
+    @property
+    def _nd_outputs(self) -> bool:
+        """True when every output variable is a TorchNDVariable."""
+        return all(isinstance(v, TorchNDVariable) for v in self._model.output_variables)
+
+    @property
+    def _scalar_inputs(self) -> bool:
+        """True when every input variable is a TorchScalarVariable."""
+        return all(
+            isinstance(v, TorchScalarVariable) for v in self._model.input_variables
+        )
+
+    @property
+    def _scalar_outputs(self) -> bool:
+        """True when every output variable is a TorchScalarVariable."""
+        return all(
+            isinstance(v, TorchScalarVariable) for v in self._model.output_variables
+        )
+
     def forward(self, x: torch.Tensor):
-        # input shape: [..., n_features] or [..., n_features, 1] for scalar variables
         x = self._validate_input(x)
         model_input = self._tensor_to_dictionary(x)
         y_model = self.evaluate_model(model_input)
         y_model = self.manipulate_output(y_model)
-        # squeeze trailing output-feature dim (K=1) for BoTorch Mean compatibility,
-        # but preserve all batch/sample dimensions
-        y = self._dictionary_to_tensor(y_model).squeeze(-1)
+        y = self._dictionary_to_tensor(y_model)
+        if self._scalar_outputs:
+            # Remove trailing output-feature dim for BoTorch Mean compatibility
+            # (K=1: (batch, 1) -> (batch,); K>1: (batch, K) unchanged)
+            y = y.squeeze(-1)
         return y
 
     def yaml(
@@ -250,46 +276,63 @@ class TorchModule(torch.nn.Module):
 
     def _tensor_to_dictionary(self, x: torch.Tensor):
         input_dict = {}
-        # Handle both old format (..., n_features) and new format (..., n_features, 1)
-        # New format requires at least 3 dimensions with last dim == 1
-        if x.ndim >= 3 and x.shape[-1] == 1:
-            # New scalar format: (..., n_features, 1)
-            # Index the second-to-last dimension and keep trailing 1
+        if self._nd_inputs:
+            # ND format: (batch, num_vars, *array_shape) — slice dim 1 per variable
+            for idx, input_name in enumerate(self.input_order):
+                input_dict[input_name] = x[:, idx, ...]
+        elif x.ndim >= 3 and x.shape[-1] == 1:
+            # Scalar new format: (..., n_features, 1) — index second-to-last dim
             for idx, input_name in enumerate(self.input_order):
                 input_dict[input_name] = x[..., idx, :]
         else:
-            # Old format: (..., n_features)
-            # Index last dimension and add trailing 1
+            # Scalar old format: (..., n_features) — index last dim, add trailing 1
             for idx, input_name in enumerate(self.input_order):
                 input_dict[input_name] = x[..., idx].unsqueeze(-1)
         return input_dict
 
     def _dictionary_to_tensor(self, y_model: dict[str, torch.Tensor]):
-        # Model outputs have shape (batch, 1) for single-sample or (batch, samples) for multi-sample
-        # We need to stack them into (..., n_outputs) format
         output_list = []
         for output_name in self.output_order:
-            output = y_model[output_name]
-            # If output has trailing 1 (single-sample), squeeze it for stacking
-            # Multi-sample outputs like (batch, samples) are kept as-is
-            if output.shape[-1] == 1:
-                output = output.squeeze(-1)
-            output_list.append(output)
+            output_list.append(y_model[output_name])
 
-        output_tensor = torch.stack(output_list, dim=-1)
-        return output_tensor
-
-    @staticmethod
-    def _validate_input(x: torch.Tensor) -> torch.Tensor:
-        if x.dim() <= 1:
-            logger.error(
-                f"Invalid input dimensions: expected at least 2D ([n_samples, n_features]), got {tuple(x.shape)}"
-            )
-            raise ValueError(
-                f"Expected input dim to be at least 2 ([n_samples, n_features]), received: {tuple(x.shape)}"
-            )
+        if self._nd_outputs:
+            # ND outputs: stack along dim 1 -> (batch, num_outputs, *array_shape)
+            return torch.stack(output_list, dim=1)
         else:
-            return x
+            # Scalar outputs: squeeze trailing feature dim then stack along last dim
+            # -> (batch, K) for K outputs
+            squeezed = [o.squeeze(-1) if o.shape[-1] == 1 else o for o in output_list]
+            return torch.stack(squeezed, dim=-1)
+
+    def _validate_input(self, x: torch.Tensor) -> torch.Tensor:
+        if self._nd_inputs:
+            # ND inputs: (batch, num_vars, *array_shape)
+            # Minimum ndim = 1 (batch) + 1 (num_vars) + len(array_shape of first var)
+            first_var = self._model.input_variables[0]
+            min_ndim = 2 + len(first_var.shape)
+            if x.dim() < min_ndim:
+                logger.error(
+                    f"Invalid input dimensions for ND variables: expected at least {min_ndim}D "
+                    f"([batch, num_vars, *array_shape] where array_shape={first_var.shape}), "
+                    f"got {tuple(x.shape)}"
+                )
+                raise ValueError(
+                    f"Expected input dim to be at least {min_ndim} "
+                    f"([batch, num_vars, *array_shape] where array_shape={first_var.shape}) "
+                    f"for TorchNDVariable inputs, received: {tuple(x.shape)}"
+                )
+        else:
+            # Scalar inputs: expect at least 2D ([batch, n_features] or [batch, n_features, 1])
+            if x.dim() <= 1:
+                logger.error(
+                    f"Invalid input dimensions: expected at least 2D ([n_samples, n_features]), "
+                    f"got {tuple(x.shape)}"
+                )
+                raise ValueError(
+                    f"Expected input dim to be at least 2 ([n_samples, n_features]), "
+                    f"received: {tuple(x.shape)}"
+                )
+        return x
 
     def register_to_mlflow(
         self,

--- a/lume_torch/models/utils.py
+++ b/lume_torch/models/utils.py
@@ -52,6 +52,8 @@ def itemize_dict(
 
 def format_inputs(
     input_dict: dict[str, Union[float, torch.Tensor]],
+    tensor_kwargs: dict[str, Union[torch.device, torch.dtype]] = None,
+    squeeze: bool = False,
 ) -> dict[str, torch.Tensor]:
     """Formats values of the input dictionary as tensors.
 
@@ -66,11 +68,16 @@ def format_inputs(
         Dictionary of input variable names to tensors.
 
     """
-    formatted_inputs = {}
-    for var_name, value in input_dict.items():
-        v = value if isinstance(value, torch.Tensor) else torch.tensor(value)
-        formatted_inputs[var_name] = v
-    return formatted_inputs
+    tensor_kwargs = tensor_kwargs or {}
+    formatted_inputs = {
+        k: (v if isinstance(v, torch.Tensor) else torch.tensor(v)).to(**tensor_kwargs)
+        for k, v in input_dict.items()
+    }
+    return (
+        {k: v.squeeze(-1) for k, v in formatted_inputs.items()}
+        if squeeze
+        else formatted_inputs
+    )
 
 
 class InputDictModel(BaseModel):

--- a/lume_torch/utils.py
+++ b/lume_torch/utils.py
@@ -177,10 +177,11 @@ def variables_from_dict(
         if key in ["input_variables", "output_variables"]:
             for var in value:
                 variable_class = get_variable(var["variable_class"])
+                var_kwargs = {k: v for k, v in var.items() if k != "variable_class"}
                 if key == "input_variables":
-                    input_variables.append(variable_class(**var))
+                    input_variables.append(variable_class(**var_kwargs))
                 elif key == "output_variables":
-                    output_variables.append(variable_class(**var))
+                    output_variables.append(variable_class(**var_kwargs))
     for variables in [input_variables, output_variables]:
         verify_unique_variable_names(variables)
     logger.debug(

--- a/lume_torch/variables.py
+++ b/lume_torch/variables.py
@@ -99,10 +99,15 @@ class DistributionVariable(Variable):
 
     unit: Optional[str] = None
 
+    model_config = ConfigDict(extra="forbid")
+
     @model_validator(mode="before")
     @classmethod
     def _compat_is_constant(cls, data: Any) -> Any:
-        return _normalize_legacy_read_only(data)
+        data = _normalize_legacy_read_only(data)
+        if isinstance(data, dict):
+            data = {k: v for k, v in data.items() if k != "variable_class"}
+        return data
 
     def validate_value(
         self, value: TDistribution, config: Optional[ConfigEnum] = None, **kwargs
@@ -159,7 +164,7 @@ class TorchScalarVariable(_BaseScalarVariable):
         a floating-point type without enforcing a specific precision.
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
     default_value: Optional[Union[Tensor, float]] = None
     dtype: Optional[torch.dtype] = None
@@ -167,7 +172,10 @@ class TorchScalarVariable(_BaseScalarVariable):
     @model_validator(mode="before")
     @classmethod
     def _compat_is_constant(cls, data: Any) -> Any:
-        return _normalize_legacy_read_only(data)
+        data = _normalize_legacy_read_only(data)
+        if isinstance(data, dict):
+            data = {k: v for k, v in data.items() if k != "variable_class"}
+        return data
 
     @field_serializer("default_value")
     def serialize_default_value(
@@ -385,7 +393,7 @@ class TorchScalarVariable(_BaseScalarVariable):
         return failed
 
 
-class TorchNDVariable(NDVariable):
+class TorchNDVariable(NDVariable):  # noqa: E303
     """Variable for PyTorch tensor data with arbitrary shape and dtype.
 
     Attributes
@@ -494,6 +502,10 @@ class TorchNDVariable(NDVariable):
             return None
         return value.tolist()
 
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, validate_assignment=True, extra="forbid"
+    )
+
     @model_validator(mode="before")
     @classmethod
     def _mark_coerced_default_value(cls, data: Any) -> Any:
@@ -509,6 +521,7 @@ class TorchNDVariable(NDVariable):
         """
         data = _normalize_legacy_read_only(data)
         if isinstance(data, dict):
+            data = {k: v for k, v in data.items() if k != "variable_class"}
             dv = data.get("default_value")
             if isinstance(dv, (list, tuple)):
                 data = dict(data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,11 @@ from typing import Any, Union
 import pytest
 
 from lume_torch.utils import variables_from_yaml
-from lume_torch.variables import TorchScalarVariable, DistributionVariable
+from lume_torch.variables import (
+    TorchScalarVariable,
+    TorchNDVariable,
+    DistributionVariable,
+)
 
 try:
     import torch
@@ -152,7 +156,61 @@ def california_module(california_model):
     return TorchModule(model=california_model)
 
 
-# GPModel fixtures
+@pytest.fixture(scope="module")
+def nd_model_and_data():
+    """A minimal TorchModel with a single TorchNDVariable input and output.
+
+    The model is a single-layer linear network mapping (C, H, W) -> (C, H, W)
+    via a learned weight on the flattened input = identity-like transform.
+    For test simplicity we use shape (2, 3) arrays.
+    """
+    array_shape = (2, 3)
+    n_elements = array_shape[0] * array_shape[1]  # 6
+
+    default_array = torch.zeros(array_shape, dtype=torch.float32)
+
+    input_var = TorchNDVariable(
+        name="array_in",
+        shape=array_shape,
+        default_value=default_array,
+    )
+    output_var = TorchNDVariable(
+        name="array_out",
+        shape=array_shape,
+    )
+
+    # Simple linear model: flatten -> linear -> reshape
+    class FlatLinear(torch.nn.Module):
+        def __init__(self, n):
+            super().__init__()
+            self.linear = torch.nn.Linear(n, n, bias=False)
+            # Initialise to identity so output == input (easy to verify)
+            torch.nn.init.eye_(self.linear.weight)
+
+        def forward(self, x):
+            batch = x.shape[0]
+            n_arrays = x.shape[1]
+            flat = x.reshape(batch, n_arrays, -1)  # (batch, 1, 6)
+            out = self.linear(flat)  # (batch, 1, 6)
+            return out.reshape(batch, n_arrays, *array_shape)  # (batch, 1, 2, 3)
+
+    nn_model = FlatLinear(n_elements)
+
+    model = TorchModel(
+        model=nn_model,
+        input_variables=[input_var],
+        output_variables=[output_var],
+        precision="single",
+        fixed_model=False,  # avoid grad-deactivation for the identity check
+    )
+
+    # A batch of 3 test arrays, each shape (2, 3)
+    test_input = torch.arange(n_elements, dtype=torch.float32).reshape(array_shape)
+    batch_input = test_input.unsqueeze(0).repeat(3, 1, 1)  # (3, 2, 3)
+
+    return model, batch_input
+
+
 @pytest.fixture(scope="session")
 def gp_variables() -> dict[
     str, Union[list[TorchScalarVariable], list[DistributionVariable]]

--- a/tests/models/test_arrange_parse.py
+++ b/tests/models/test_arrange_parse.py
@@ -1,0 +1,364 @@
+"""Direct unit tests for TorchModel._arrange_inputs and _parse_outputs.
+
+These test the internal methods directly with known tensors, covering
+edge cases and error paths that aren't exercised by the integration
+tests in test_torch_model.py.
+"""
+
+import pytest
+import torch
+
+from lume_torch.models import TorchModel
+from lume_torch.variables import TorchScalarVariable, TorchNDVariable
+
+
+# ---------------------------------------------------------------------------
+# Helpers: minimal TorchModel instances with identity nn.Module
+# ---------------------------------------------------------------------------
+
+
+class _Identity(torch.nn.Module):
+    def forward(self, x):
+        return x
+
+
+def _scalar_model(n_in=3, n_out=2, precision="double"):
+    """TorchModel with n_in scalar inputs and n_out scalar outputs."""
+    input_vars = [
+        TorchScalarVariable(
+            name=f"x{i}", default_value=float(i), value_range=(0.0, 10.0)
+        )
+        for i in range(n_in)
+    ]
+    output_vars = [TorchScalarVariable(name=f"y{i}") for i in range(n_out)]
+    return TorchModel(
+        model=_Identity(),
+        input_variables=input_vars,
+        output_variables=output_vars,
+        precision=precision,
+    )
+
+
+def _nd_model(array_shape=(2, 3), n_in=1, n_out=1, precision="single"):
+    """TorchModel with n_in ND inputs and n_out ND outputs."""
+    input_vars = [
+        TorchNDVariable(
+            name=f"arr_in{i}",
+            shape=array_shape,
+            default_value=torch.zeros(array_shape),
+        )
+        for i in range(n_in)
+    ]
+    output_vars = [
+        TorchNDVariable(name=f"arr_out{i}", shape=array_shape) for i in range(n_out)
+    ]
+    return TorchModel(
+        model=_Identity(),
+        input_variables=input_vars,
+        output_variables=output_vars,
+        precision=precision,
+        fixed_model=False,
+    )
+
+
+# =========================================================================
+# _arrange_inputs — Scalar path
+# =========================================================================
+
+
+class TestArrangeInputsScalar:
+    """Tests for _arrange_inputs with TorchScalarVariable inputs."""
+
+    def test_empty_dict_returns_defaults(self):
+        """Empty formatted_inputs → (1, n_in) tensor of defaults."""
+        model = _scalar_model(n_in=3)
+        result = model._arrange_inputs({})
+        assert result.shape == (1, 3)
+        expected = torch.tensor([[0.0, 1.0, 2.0]], dtype=torch.double)
+        assert torch.allclose(result, expected)
+
+    def test_single_0d_input(self):
+        """Single 0D tensor input → (1, n_in) with default fill."""
+        model = _scalar_model(n_in=3)
+        result = model._arrange_inputs({"x0": torch.tensor(5.0, dtype=torch.double)})
+        assert result.shape == (1, 3)
+        assert result[0, 0].item() == 5.0
+        # x1 and x2 should be defaults
+        assert result[0, 1].item() == 1.0
+        assert result[0, 2].item() == 2.0
+
+    def test_batched_1d_input(self):
+        """1D tensor → (batch, n_in) with default fill for missing vars."""
+        model = _scalar_model(n_in=3)
+        result = model._arrange_inputs(
+            {
+                "x0": torch.tensor([10.0, 20.0, 30.0], dtype=torch.double),
+            }
+        )
+        assert result.shape == (3, 3)
+        assert torch.allclose(
+            result[:, 0], torch.tensor([10.0, 20.0, 30.0], dtype=torch.double)
+        )
+        # defaults broadcast
+        assert torch.all(result[:, 1] == 1.0)
+        assert torch.all(result[:, 2] == 2.0)
+
+    def test_trailing_feature_dim_squeezed(self):
+        """Input shape (batch, 1) → (batch, n_in)."""
+        model = _scalar_model(n_in=2)
+        result = model._arrange_inputs(
+            {
+                "x0": torch.tensor([[5.0], [6.0]], dtype=torch.double),
+                "x1": torch.tensor([[7.0], [8.0]], dtype=torch.double),
+            }
+        )
+        assert result.shape == (2, 2)
+        assert torch.allclose(
+            result, torch.tensor([[5.0, 7.0], [6.0, 8.0]], dtype=torch.double)
+        )
+
+    def test_3d_batch_samples_feature(self):
+        """Input shape (batch, samples, 1) → (batch, samples, n_in)."""
+        model = _scalar_model(n_in=2)
+        x0 = torch.ones(2, 3, 1, dtype=torch.double) * 5.0
+        x1 = torch.ones(2, 3, 1, dtype=torch.double) * 9.0
+        result = model._arrange_inputs({"x0": x0, "x1": x1})
+        assert result.shape == (2, 3, 2)
+        assert torch.all(result[..., 0] == 5.0)
+        assert torch.all(result[..., 1] == 9.0)
+
+    def test_inconsistent_batch_shapes_raises(self):
+        """Different batch shapes across inputs → ValueError."""
+        model = _scalar_model(n_in=2)
+        with pytest.raises(ValueError, match="Inconsistent batch shapes"):
+            model._arrange_inputs(
+                {
+                    "x0": torch.tensor([1.0, 2.0], dtype=torch.double),  # batch=2
+                    "x1": torch.tensor([1.0, 2.0, 3.0], dtype=torch.double),  # batch=3
+                }
+            )
+
+    def test_invalid_scalar_shape_raises(self):
+        """Shape (3, 2) for a scalar input → ValueError."""
+        model = _scalar_model(n_in=2)
+        with pytest.raises(ValueError, match="unexpected shape"):
+            model._arrange_inputs(
+                {
+                    "x0": torch.tensor(
+                        [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=torch.double
+                    ),
+                }
+            )
+
+    def test_all_inputs_provided(self):
+        """All inputs provided, no default fill needed."""
+        model = _scalar_model(n_in=2)
+        result = model._arrange_inputs(
+            {
+                "x0": torch.tensor([1.0, 2.0], dtype=torch.double),
+                "x1": torch.tensor([3.0, 4.0], dtype=torch.double),
+            }
+        )
+        assert result.shape == (2, 2)
+        assert torch.allclose(
+            result, torch.tensor([[1.0, 3.0], [2.0, 4.0]], dtype=torch.double)
+        )
+
+    def test_preserves_input_ordering(self):
+        """Dict insertion order doesn't matter — variable list order is used."""
+        model = _scalar_model(n_in=3)
+        # Provide in reverse order
+        result = model._arrange_inputs(
+            {
+                "x2": torch.tensor([30.0], dtype=torch.double),
+                "x0": torch.tensor([10.0], dtype=torch.double),
+            }
+        )
+        assert result.shape == (1, 3)
+        assert result[0, 0].item() == 10.0  # x0
+        assert result[0, 1].item() == 1.0  # x1 default
+        assert result[0, 2].item() == 30.0  # x2
+
+
+# =========================================================================
+# _arrange_inputs — ND path
+# =========================================================================
+
+
+class TestArrangeInputsND:
+    """Tests for _arrange_inputs with TorchNDVariable inputs."""
+
+    def test_single_unbatched_nd(self):
+        """Single unbatched array → (1, 1, *shape)."""
+        model = _nd_model(array_shape=(2, 3), n_in=1)
+        arr = torch.ones(2, 3)
+        result = model._arrange_inputs({"arr_in0": arr})
+        assert result.shape == (1, 1, 2, 3)
+
+    def test_batched_nd(self):
+        """Batched array (batch, *shape) → (batch, 1, *shape)."""
+        model = _nd_model(array_shape=(2, 3), n_in=1)
+        arr = torch.ones(5, 2, 3)
+        result = model._arrange_inputs({"arr_in0": arr})
+        assert result.shape == (5, 1, 2, 3)
+
+    def test_multi_nd_inputs(self):
+        """Two ND inputs → (batch, 2, *shape)."""
+        model = _nd_model(array_shape=(4,), n_in=2)
+        a0 = torch.ones(3, 4)
+        a1 = torch.zeros(3, 4)
+        result = model._arrange_inputs({"arr_in0": a0, "arr_in1": a1})
+        assert result.shape == (3, 2, 4)
+        assert torch.all(result[:, 0, :] == 1.0)
+        assert torch.all(result[:, 1, :] == 0.0)
+
+    def test_nd_wrong_sample_shape_raises(self):
+        """Wrong trailing shape → ValueError."""
+        model = _nd_model(array_shape=(2, 3), n_in=1)
+        with pytest.raises(ValueError, match="expected sample shape"):
+            model._arrange_inputs({"arr_in0": torch.ones(2, 4)})
+
+    def test_nd_inconsistent_batch_raises(self):
+        """Different batch sizes across ND inputs → ValueError."""
+        model = _nd_model(array_shape=(4,), n_in=2)
+        with pytest.raises(ValueError, match="inconsistent batch shapes"):
+            model._arrange_inputs(
+                {
+                    "arr_in0": torch.ones(3, 4),
+                    "arr_in1": torch.ones(5, 4),
+                }
+            )
+
+    def test_nd_missing_input_uses_default_unbatched(self):
+        """Missing ND input filled with default; unbatched → singleton batch."""
+        model = _nd_model(array_shape=(4, 3), n_in=2)
+        a0 = torch.ones(4, 3)
+        result = model._arrange_inputs({"arr_in0": a0})
+        assert result.shape == (1, 2, 4, 3)
+        assert torch.all(result[:, 0, :, :] == 1.0)
+        assert torch.all(result[:, 1, :, :] == 0.0)  # default
+
+    def test_nd_missing_input_broadcasts_to_batch(self):
+        """Missing ND input (singleton default) broadcasts to match batch."""
+        model = _nd_model(array_shape=(4, 3), n_in=2)
+        a0 = torch.ones(3, 4, 3)
+        result = model._arrange_inputs({"arr_in0": a0})
+        assert result.shape == (3, 2, 4, 3)
+        assert torch.all(result[:, 0, :, :] == 1.0)
+        assert torch.all(result[:, 1, :, :] == 0.0)  # default broadcast to batch=3
+
+
+# =========================================================================
+# _arrange_inputs — Mixed variable types
+# =========================================================================
+
+
+class TestArrangeInputsMixed:
+    """Tests for the mixed scalar + ND error path."""
+
+    def test_mixed_raises_not_implemented(self):
+        input_vars = [
+            TorchScalarVariable(name="s", default_value=1.0, value_range=(0.0, 5.0)),
+            TorchNDVariable(name="a", shape=(3,), default_value=torch.zeros(3)),
+        ]
+        output_vars = [TorchScalarVariable(name="y")]
+        model = TorchModel(
+            model=_Identity(),
+            input_variables=input_vars,
+            output_variables=output_vars,
+            fixed_model=False,
+        )
+        with pytest.raises(NotImplementedError, match="Mixing"):
+            model._arrange_inputs({"s": torch.tensor(1.0)})
+
+
+# =========================================================================
+# _parse_outputs — Scalar
+# =========================================================================
+
+
+class TestParseOutputsScalar:
+    """Tests for _parse_outputs with scalar output variables."""
+
+    def test_0d_single_output(self):
+        """0D tensor → dict with shape (1, 1)."""
+        model = _scalar_model(n_out=1)
+        result = model._parse_outputs(torch.tensor(5.0, dtype=torch.double))
+        assert result["y0"].shape == (1, 1)
+        assert result["y0"].item() == 5.0
+
+    def test_1d_single_output_is_batch(self):
+        """1D tensor (batch,) for single scalar output → (batch, 1)."""
+        model = _scalar_model(n_out=1)
+        result = model._parse_outputs(torch.tensor([1.0, 2.0, 3.0], dtype=torch.double))
+        assert result["y0"].shape == (3, 1)
+
+    def test_1d_multi_output_is_features(self):
+        """1D tensor (features,) for multi scalar output → per-output (1, 1)."""
+        model = _scalar_model(n_out=3)
+        result = model._parse_outputs(
+            torch.tensor([10.0, 20.0, 30.0], dtype=torch.double)
+        )
+        assert len(result) == 3
+        for i, name in enumerate(["y0", "y1", "y2"]):
+            assert result[name].shape == (1, 1)
+            assert result[name].item() == (i + 1) * 10.0
+
+    def test_2d_single_output(self):
+        """2D tensor (batch, 1) for single scalar output → kept as-is."""
+        model = _scalar_model(n_out=1)
+        t = torch.tensor([[1.0], [2.0]], dtype=torch.double)
+        result = model._parse_outputs(t)
+        assert result["y0"].shape == (2, 1)
+
+    def test_2d_multi_output(self):
+        """2D tensor (batch, features) for multi scalar output → per-output (batch, 1)."""
+        model = _scalar_model(n_out=2)
+        t = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=torch.double)
+        result = model._parse_outputs(t)
+        assert result["y0"].shape == (3, 1)
+        assert result["y1"].shape == (3, 1)
+        assert torch.allclose(
+            result["y0"], torch.tensor([[1.0], [3.0], [5.0]], dtype=torch.double)
+        )
+        assert torch.allclose(
+            result["y1"], torch.tensor([[2.0], [4.0], [6.0]], dtype=torch.double)
+        )
+
+    def test_3d_single_output(self):
+        """3D tensor (batch, samples, 1) for single scalar output."""
+        model = _scalar_model(n_out=1)
+        t = torch.ones(2, 3, 1, dtype=torch.double)
+        result = model._parse_outputs(t)
+        assert result["y0"].shape == (2, 3, 1)
+
+
+# =========================================================================
+# _parse_outputs — ND
+# =========================================================================
+
+
+class TestParseOutputsND:
+    """Tests for _parse_outputs with NDVariable outputs."""
+
+    def test_single_nd_output_squeezes_dim1(self):
+        """(batch, 1, H, W) → squeezed to (batch, H, W)."""
+        model = _nd_model(array_shape=(2, 3), n_out=1)
+        t = torch.ones(4, 1, 2, 3)
+        result = model._parse_outputs(t)
+        assert result["arr_out0"].shape == (4, 2, 3)
+
+    def test_single_nd_output_no_squeeze_needed(self):
+        """(batch, H, W) with no extra dim 1 → unchanged."""
+        model = _nd_model(array_shape=(2, 3), n_out=1)
+        t = torch.ones(4, 2, 3)
+        result = model._parse_outputs(t)
+        # dim 1 is 2 (not 1), so squeeze(1) is a no-op
+        assert result["arr_out0"].shape == (4, 2, 3)
+
+    def test_single_nd_unbatched(self):
+        """(1, 1, H, W) → squeeze dim 1 → (1, H, W)."""
+        model = _nd_model(array_shape=(2, 3), n_out=1)
+        t = torch.ones(1, 1, 2, 3)
+        result = model._parse_outputs(t)
+        assert result["arr_out0"].shape == (1, 2, 3)

--- a/tests/models/test_torch_module.py
+++ b/tests/models/test_torch_module.py
@@ -193,7 +193,7 @@ class TestTorchModule:
             input_order=[california_model.input_names[0]],
         )
         # 2D old-format: (batch, n_features) = (3, 1) — ndim=2, last dim=1
-        input_2d = deepcopy(california_test_input_tensor[:, 0].unsqueeze(-1))  # (3, 1)
+        input_2d = california_test_input_tensor[:, 0, 0].unsqueeze(-1)  # (3, 1)
         # 3D new-format: (batch, n_features, 1) = (3, 1, 1) — ndim=3
         input_3d = input_2d.unsqueeze(-1)  # (3, 1, 1)
 
@@ -201,7 +201,7 @@ class TestTorchModule:
         result_3d = lume_module(input_3d)
 
         assert tuple(result_2d.shape) == (3,)
-        assert all(torch.isclose(result_2d, result_3d))
+        assert torch.all(torch.isclose(result_2d, result_3d))
 
     def test_module_call_single_sample(
         self, california_test_input_tensor, california_module
@@ -212,7 +212,7 @@ class TestTorchModule:
         )  # shape (1,8)
         result = california_module(input_tensor)
 
-        assert tuple(result.size()) == ()
+        assert tuple(result.size()) == (1,)
         assert_california_module_result(result, idx=idx)
 
     def test_module_call_n_samples(
@@ -244,7 +244,7 @@ class TestTorchModule:
         )
         result = lume_module(input_tensor)
 
-        assert tuple(result.size()) == ()
+        assert tuple(result.size()) == (1,)
         assert_california_module_result(result, idx=idx)
 
     def test_module_call_manipulate_output(

--- a/tests/models/test_torch_module.py
+++ b/tests/models/test_torch_module.py
@@ -5,16 +5,11 @@ from copy import deepcopy
 
 import pytest
 
-try:
-    import torch
-    from botorch.models import SingleTaskGP
-    from lume_torch.models import TorchModel, TorchModule
+import torch
+from botorch.models import SingleTaskGP
+from lume_torch.models import TorchModel, TorchModule
 
-    torch.manual_seed(42)
-except ImportError:
-    pass
-
-random.seed(42)
+torch.manual_seed(42)
 
 
 def assert_california_module_result(result: torch.Tensor, idx=None):
@@ -320,3 +315,40 @@ class TestTorchModule:
         assert tuple(test_y.shape) == (test_x.shape[0],)
         # GP should just predict the prior mean values for the posterior
         assert all(torch.isclose(mean, test_y))
+
+
+class TestTorchModuleND:
+    def test_nd_module_forward_single_batch(self, nd_model_and_data):
+        model, batch_input = nd_model_and_data
+        module = TorchModule(model=model)
+        # Input: (batch, num_vars, *array_shape) = (3, 1, 2, 3)
+        x = batch_input.unsqueeze(1)  # (3, 1, 2, 3)
+        result = module(x)
+        # Output: (batch, num_outputs, *array_shape) = (3, 1, 2, 3)
+        assert tuple(result.shape) == (3, 1, 2, 3)
+        # Identity model: output should equal input
+        assert torch.allclose(result[:, 0, :, :], batch_input, atol=1e-5)
+
+    def test_nd_module_validate_input_too_few_dims(self, nd_model_and_data):
+        model, batch_input = nd_model_and_data
+        module = TorchModule(model=model)
+        # array_shape=(2,3) so min_ndim=4; (3,2,3) is 3D — too few
+        with pytest.raises(ValueError, match="at least 4"):
+            module(batch_input)  # shape (3, 2, 3) — 3D, too few
+        with pytest.raises(ValueError, match="at least 4"):
+            module(batch_input[0])  # shape (2, 3) — 2D, too few
+
+    def test_nd_all_nd_property(self, nd_model_and_data):
+        model, _ = nd_model_and_data
+        module = TorchModule(model=model)
+        assert module._nd_inputs is True
+        assert module._nd_outputs is True
+        assert module._scalar_inputs is False
+        assert module._scalar_outputs is False
+
+    def test_scalar_all_scalars_property(self, california_model):
+        module = TorchModule(model=california_model)
+        assert module._scalar_inputs is True
+        assert module._scalar_outputs is True
+        assert module._nd_inputs is False
+        assert module._nd_outputs is False

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -227,6 +227,18 @@ class TestBaseModel:
                 {"fixed": 9.0, normal_var.name: 2.0}, check_read_only=True
             )
 
+    def test_input_validation_config_unknown_key_raises(self, simple_variables):
+        """Setting input_validation_config with a key that isn't an input variable name raises."""
+        example_model = ExampleModel(**simple_variables)
+        with pytest.raises(ValueError, match="unknown variable name"):
+            example_model.input_validation_config = {"nonexistent_var": "error"}
+
+    def test_output_validation_config_unknown_key_raises(self, simple_variables):
+        """Setting output_validation_config with a key that isn't an output variable name raises."""
+        example_model = ExampleModel(**simple_variables)
+        with pytest.raises(ValueError, match="unknown variable name"):
+            example_model.output_validation_config = {"nonexistent_var": "error"}
+
     def test_output_validation(self, simple_variables):
         example_model = ExampleModel(**simple_variables)
         output_variables = simple_variables["output_variables"]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -152,7 +152,7 @@ class TestBaseModel:
 
     def test_input_validation_missing_input_validates_default(self, simple_variables):
         """Variables absent from input_dict have their default_value validated
-        instead of raising, when check_no_missing_inputs is False (the default).
+        instead of raising, when require_all_inputs is False (the default).
         Uses model_construct to bypass pydantic's own construction-time check
         so that we can set an out-of-range default and confirm input_validation
         catches it."""
@@ -182,24 +182,24 @@ class TestBaseModel:
             model.input_validation({"good": 2.0})
 
     def test_input_validation_check_no_missing_inputs(self, simple_variables):
-        """check_no_missing_inputs=True raises ValueError when a variable is absent."""
+        """require_all_inputs=True raises ValueError when a variable is absent."""
         example_model = ExampleModel(**simple_variables)
         input_variables = simple_variables["input_variables"]
+
+        example_model.require_all_inputs = True
 
         with pytest.raises(ValueError, match="Missing required input variable"):
             example_model.input_validation(
                 {input_variables[0].name: 1.0},
-                check_no_missing_inputs=True,
             )
 
         # providing all inputs does not raise
         example_model.input_validation(
             {input_variables[0].name: 1.0, input_variables[1].name: 2.0},
-            check_no_missing_inputs=True,
         )
 
     def test_input_validation_check_read_only(self, simple_variables):
-        """check_read_only=True calls validate_read_only for read-only variables."""
+        """Read-only enforcement is unconditional — driven by var.read_only."""
         read_only_var = TorchScalarVariable(
             name="fixed",
             default_value=1.0,
@@ -213,19 +213,11 @@ class TestBaseModel:
         model.input_validation_config = {"fixed": "error"}
 
         # value matches default — should pass
-        model.input_validation(
-            {"fixed": 1.0, normal_var.name: 2.0}, check_read_only=False
-        )
+        model.input_validation({"fixed": 1.0, normal_var.name: 2.0})
 
-        model.input_validation(
-            {"fixed": 1.0, normal_var.name: 2.0}, check_read_only=True
-        )
-
-        # value differs from default — validate_read_only should raise
+        # value differs from default — always raises (no opt-out toggle)
         with pytest.raises(Exception):
-            model.input_validation(
-                {"fixed": 9.0, normal_var.name: 2.0}, check_read_only=True
-            )
+            model.input_validation({"fixed": 9.0, normal_var.name: 2.0})
 
     def test_input_validation_config_unknown_key_raises(self, simple_variables):
         """Setting input_validation_config with a key that isn't an input variable name raises."""

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -137,6 +137,90 @@ class TestBaseModel:
         input_dict[input_variables[0].name] = 6.0
         example_model.input_validation(input_dict)
 
+    def test_input_validation_partial_config(self, simple_variables):
+        example_model = ExampleModel(**simple_variables)
+        input_variables = simple_variables["input_variables"]
+
+        example_model.input_validation_config = {input_variables[0].name: "error"}
+
+        input_dict = {input_variables[0].name: 6.0, input_variables[1].name: 2.0}
+        with pytest.raises(ValueError):
+            example_model.input_validation(input_dict)
+
+        input_dict = {input_variables[0].name: 1.0, input_variables[1].name: 99.0}
+        example_model.input_validation(input_dict)
+
+    def test_input_validation_missing_input_validates_default(self, simple_variables):
+        """Variables absent from input_dict have their default_value validated
+        instead of raising, when check_no_missing_inputs is False (the default).
+        Uses model_construct to bypass pydantic's own construction-time check
+        so that we can set an out-of-range default and confirm input_validation
+        catches it."""
+        # Bypass pydantic on both the variable AND the model to get an invalid default in
+        var_bad = TorchScalarVariable.model_construct(
+            name="bad",
+            default_value=99.0,
+            value_range=(0.0, 5.0),
+            read_only=False,
+            default_validation_config="error",
+        )
+        var_good = TorchScalarVariable(name="good", default_value=2.0)
+        model = ExampleModel.model_construct(
+            input_variables=[var_bad, var_good],
+            output_variables=simple_variables["output_variables"],
+            input_validation_config=None,
+            output_validation_config=None,
+        )
+        # "bad" is absent; its default (99.0) is outside range and config is "error"
+        with pytest.raises(ValueError):
+            model.input_validation({"good": 2.0})
+
+    def test_input_validation_check_no_missing_inputs(self, simple_variables):
+        """check_no_missing_inputs=True raises ValueError when a variable is absent."""
+        example_model = ExampleModel(**simple_variables)
+        input_variables = simple_variables["input_variables"]
+
+        with pytest.raises(ValueError, match="Missing required input variable"):
+            example_model.input_validation(
+                {input_variables[0].name: 1.0},
+                check_no_missing_inputs=True,
+            )
+
+        # providing all inputs does not raise
+        example_model.input_validation(
+            {input_variables[0].name: 1.0, input_variables[1].name: 2.0},
+            check_no_missing_inputs=True,
+        )
+
+    def test_input_validation_check_read_only(self, simple_variables):
+        """check_read_only=True calls validate_read_only for read-only variables."""
+        read_only_var = TorchScalarVariable(
+            name="fixed",
+            default_value=1.0,
+            read_only=True,
+        )
+        normal_var = simple_variables["input_variables"][1]
+        model = ExampleModel(
+            input_variables=[read_only_var, normal_var],
+            output_variables=simple_variables["output_variables"],
+        )
+        model.input_validation_config = {"fixed": "error"}
+
+        # value matches default — should pass
+        model.input_validation(
+            {"fixed": 1.0, normal_var.name: 2.0}, check_read_only=False
+        )
+
+        model.input_validation(
+            {"fixed": 1.0, normal_var.name: 2.0}, check_read_only=True
+        )
+
+        # value differs from default — validate_read_only should raise
+        with pytest.raises(Exception):
+            model.input_validation(
+                {"fixed": 9.0, normal_var.name: 2.0}, check_read_only=True
+            )
+
     def test_output_validation(self, simple_variables):
         example_model = ExampleModel(**simple_variables)
         output_variables = simple_variables["output_variables"]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -175,6 +175,12 @@ class TestBaseModel:
         with pytest.raises(ValueError):
             model.input_validation({"good": 2.0})
 
+        # Try with no default
+        model.input_variables[0].default_value = None
+        # "bad" is absent; tries to grab the default but it's None, which should raise a ValueError about missing required input
+        with pytest.raises(ValueError):
+            model.input_validation({"good": 2.0})
+
     def test_input_validation_check_no_missing_inputs(self, simple_variables):
         """check_no_missing_inputs=True raises ValueError when a variable is absent."""
         example_model = ExampleModel(**simple_variables)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -219,6 +219,20 @@ class TestBaseModel:
         with pytest.raises(Exception):
             model.input_validation({"fixed": 9.0, normal_var.name: 2.0})
 
+    def test_input_validation_read_only_no_default_raises(self, simple_variables):
+        """Read-only input with no default_value raises when a value is provided."""
+        read_only_no_default = TorchScalarVariable(name="broken", read_only=True)
+        normal_var = simple_variables["input_variables"][1]
+        model = ExampleModel.model_construct(
+            input_variables=[read_only_no_default, normal_var],
+            output_variables=simple_variables["output_variables"],
+            input_validation_config=None,
+            output_validation_config=None,
+            require_all_inputs=False,
+        )
+        with pytest.raises(ValueError, match="read-only but has no default value"):
+            model.input_validation({"broken": 1.0, normal_var.name: 2.0})
+
     def test_input_validation_config_unknown_key_raises(self, simple_variables):
         """Setting input_validation_config with a key that isn't an input variable name raises."""
         example_model = ExampleModel(**simple_variables)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 import os
 
 import pytest
+import torch
 
+from lume_torch.models.utils import format_inputs
 from lume_torch.utils import (
     verify_unique_variable_names,
     variables_as_yaml,
@@ -42,3 +44,34 @@ def test_variables_as_and_from_yaml(simple_variables):
     os.remove(file)
     assert simple_variables["input_variables"] == variables[0]
     assert simple_variables["output_variables"] == variables[1]
+
+
+class TestFormatInputs:
+    def test_converts_floats_to_tensors(self):
+        result = format_inputs({"x": 1.0, "y": 2.0})
+        assert isinstance(result["x"], torch.Tensor)
+        assert isinstance(result["y"], torch.Tensor)
+        assert result["x"].item() == pytest.approx(1.0)
+
+    def test_passthrough_tensors(self):
+        t = torch.tensor([3.0, 4.0])
+        result = format_inputs({"x": t})
+        assert torch.equal(result["x"], t)
+
+    def test_none_tensor_kwargs_does_not_raise(self):
+        # tensor_kwargs=None (the default) must not cause a TypeError
+        result = format_inputs({"x": 1.0}, tensor_kwargs=None)
+        assert isinstance(result["x"], torch.Tensor)
+
+        result = format_inputs({"x": 1.0}, tensor_kwargs={"dtype": torch.float64})
+        assert result["x"].dtype == torch.float64
+
+    def test_squeeze_false_preserves_shape(self):
+        t = torch.tensor([[1.0, 2.0]])  # shape (1, 2)
+        result = format_inputs({"x": t}, squeeze=False)
+        assert result["x"].shape == (1, 2)
+
+    def test_squeeze_true_removes_last_dim(self):
+        t = torch.tensor([[1.0], [2.0]])  # shape (2, 1)
+        result = format_inputs({"x": t}, squeeze=True)
+        assert result["x"].shape == (2,)

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -335,6 +335,11 @@ class TestTorchScalarVariable:
         var = TorchScalarVariable(name="test", read_only=False, is_constant=True)
         assert var.read_only is False
 
+    def test_unknown_field_raises(self):
+        """Misspelled or unknown fields should raise a ValidationError."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            TorchScalarVariable(name="test", range=(0.0, 1.0))  # should be value_range
+
 
 class TestTorchNDVariable:
     """Tests for TorchNDVariable class."""
@@ -345,6 +350,11 @@ class TestTorchNDVariable:
         assert var.name == "test_nd"
         assert var.shape == (10, 20)
         assert var.dtype == torch.float32
+
+    def test_unknown_field_raises(self):
+        """Misspelled or unknown fields should raise a ValidationError."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            TorchNDVariable(name="test", shape=(4,), shpe=(4,))  # typo: shpe vs shape
 
     def test_missing_shape_raises_validation_error(self):
         """Test that missing shape raises ValidationError."""


### PR DESCRIPTION
- Clean up validation across models
- improve error handling for missing default values
- enforce dict keys in model (avoids errors like specifying `range` instead of `value_range`)
- make output dimensionality consistent
- add `TorchNDVariable` support in `TorchModule`
- clean up `_arrange_inputs` and `_parse_outputs` in `TorchModel`, add unit tests, and fix default value broadcasting to batch size in `NDVariable` branch
- use class attributes to validate `read_only` values and whether all inputs are required/passed
- require all `read_only` vars have `default_value`

Left to-do:
- [ ] review and clarify some tests