### PR TITLE
Setting control variables 

### DIFF
--- a/lume_torch/models/torch_module.py
+++ b/lume_torch/models/torch_module.py
@@ -384,7 +384,7 @@ class FixedVariableModel(torch.nn.Module):
 
     """
 
-    def __init__(self, model: TorchModule, fixed_values):
+    def __init__(self, model: TorchModule, fixed_values, control_variables):
         """Initialize the FixedVariableModel class.
 
         This constructor sets up the model wrapper that separates control variables (to be optimized) from fixed
@@ -398,14 +398,14 @@ class FixedVariableModel(torch.nn.Module):
         fixed_values : dict of str to float
             Dictionary mapping PV (process variable) names to their initial measured values
             for all non-control variables
+        control_variable : list of control variables (to be vocs.variable_names to preserve the
+        variable ordering in xopt vocs)
 
         """
         super(FixedVariableModel, self).__init__()
         self.model = model
         self.all_inputs = list(model.input_order)
-        self.control_variables = [
-            pv for pv in self.all_inputs if pv not in fixed_values
-        ]
+        self.control_variables = control_variables
 
         # Create a buffer tensor to store the full input template
         # This is updated ONCE when fixed variables change, not on every forward call

--- a/tests/models/test_fixed_variable_model.py
+++ b/tests/models/test_fixed_variable_model.py
@@ -47,7 +47,7 @@ def synthetic_lume_torch():
 @pytest.fixture
 def prior_model(synthetic_lume_torch):
     """Create FixedVariableModel with y fixed at 1.0"""
-    return FixedVariableModel(model=synthetic_lume_torch, fixed_values={"y": 1.0})
+    return FixedVariableModel(model=synthetic_lume_torch, fixed_values={"y": 1.0}, control_variables=["x"])
 
 
 def test_initialization(prior_model):
@@ -142,3 +142,70 @@ def test_device_compatibility(prior_model):
         x = x.cuda()
         output = prior_model(x)
         assert output.device.type == "cuda"
+
+def test_control_variable_ordering(synthetic_lume_torch):
+    """Test that control variable ordering is preserved."""
+    # Test with control variables in specific order
+    prior_model = FixedVariableModel(
+        model=synthetic_lume_torch,
+        fixed_values={"y": 1.0},
+        control_variables=["x"]  # Explicit ordering
+    )
+    assert prior_model.control_variables == ["x"]
+    assert prior_model.control_indices.tolist() == [0]
+
+
+def test_multiple_control_variables():
+    """Test with multiple control variables and verify ordering."""
+    
+    class MultiVarModel(torch.nn.Module):
+        def forward(self, X):
+            # f(a, b, c, d) = a + 2*b + 3*c + 4*d
+            return X[..., 0] + 2*X[..., 1] + 3*X[..., 2] + 4*X[..., 3]
+
+    input_variables = [
+        TorchScalarVariable(name="a", default_value=0.0, value_range=[0.0, 1.0]),
+        TorchScalarVariable(name="b", default_value=0.0, value_range=[0.0, 1.0]),
+        TorchScalarVariable(name="c", default_value=0.0, value_range=[0.0, 1.0]),
+        TorchScalarVariable(name="d", default_value=0.0, value_range=[0.0, 1.0]),
+    ]
+
+    output_variables = [TorchScalarVariable(name="f")]
+
+    torch_model = TorchModel(
+        model=MultiVarModel(),
+        input_variables=input_variables,
+        output_variables=output_variables,
+    )
+
+    lume_module = TorchModule(model=torch_model)
+
+    # Fix b and d, control a and c
+    prior_model = FixedVariableModel(
+        model=lume_module,
+        fixed_values={"b": 1.0, "d": 1.0},
+        control_variables=["a", "c"]  # Explicit order
+    )
+
+    # Test with a=2.0, c=3.0 (b=1.0, d=1.0 fixed)
+    x = torch.tensor([[2.0, 3.0]], dtype=torch.float32)
+    output = prior_model(x)
+
+    # Expected: 2 + 2*1 + 3*3 + 4*1 = 2 + 2 + 9 + 4 = 17
+    assert abs(output.item() - 17.0) < 1e-5
+
+
+def test_empty_control_variables(synthetic_lume_torch):
+    """Test edge case with no control variables (all fixed)."""
+    prior_model = FixedVariableModel(
+        model=synthetic_lume_torch,
+        fixed_values={"x": 2.0, "y": 1.0},
+        control_variables=[]
+    )
+    
+    # Empty input tensor
+    x = torch.tensor([[]], dtype=torch.float32)
+    output = prior_model(x)
+    
+    # Expected: 0.5 * 4 + 1 = 3.0
+    assert abs(output.item() - 3.0) < 1e-5

--- a/tests/models/test_fixed_variable_model.py
+++ b/tests/models/test_fixed_variable_model.py
@@ -47,7 +47,9 @@ def synthetic_lume_torch():
 @pytest.fixture
 def prior_model(synthetic_lume_torch):
     """Create FixedVariableModel with y fixed at 1.0"""
-    return FixedVariableModel(model=synthetic_lume_torch, fixed_values={"y": 1.0}, control_variables=["x"])
+    return FixedVariableModel(
+        model=synthetic_lume_torch, fixed_values={"y": 1.0}, control_variables=["x"]
+    )
 
 
 def test_initialization(prior_model):
@@ -143,13 +145,14 @@ def test_device_compatibility(prior_model):
         output = prior_model(x)
         assert output.device.type == "cuda"
 
+
 def test_control_variable_ordering(synthetic_lume_torch):
     """Test that control variable ordering is preserved."""
     # Test with control variables in specific order
     prior_model = FixedVariableModel(
         model=synthetic_lume_torch,
         fixed_values={"y": 1.0},
-        control_variables=["x"]  # Explicit ordering
+        control_variables=["x"],  # Explicit ordering
     )
     assert prior_model.control_variables == ["x"]
     assert prior_model.control_indices.tolist() == [0]
@@ -157,11 +160,11 @@ def test_control_variable_ordering(synthetic_lume_torch):
 
 def test_multiple_control_variables():
     """Test with multiple control variables and verify ordering."""
-    
+
     class MultiVarModel(torch.nn.Module):
         def forward(self, X):
             # f(a, b, c, d) = a + 2*b + 3*c + 4*d
-            return X[..., 0] + 2*X[..., 1] + 3*X[..., 2] + 4*X[..., 3]
+            return X[..., 0] + 2 * X[..., 1] + 3 * X[..., 2] + 4 * X[..., 3]
 
     input_variables = [
         TorchScalarVariable(name="a", default_value=0.0, value_range=[0.0, 1.0]),
@@ -184,7 +187,7 @@ def test_multiple_control_variables():
     prior_model = FixedVariableModel(
         model=lume_module,
         fixed_values={"b": 1.0, "d": 1.0},
-        control_variables=["a", "c"]  # Explicit order
+        control_variables=["a", "c"],  # Explicit order
     )
 
     # Test with a=2.0, c=3.0 (b=1.0, d=1.0 fixed)
@@ -200,12 +203,12 @@ def test_empty_control_variables(synthetic_lume_torch):
     prior_model = FixedVariableModel(
         model=synthetic_lume_torch,
         fixed_values={"x": 2.0, "y": 1.0},
-        control_variables=[]
+        control_variables=[],
     )
-    
+
     # Empty input tensor
     x = torch.tensor([[]], dtype=torch.float32)
     output = prior_model(x)
-    
+
     # Expected: 0.5 * 4 + 1 = 3.0
     assert abs(output.item() - 3.0) < 1e-5


### PR DESCRIPTION
During MD, we observed that since we are computing control variables by subtracting the fixed variables from all variables, the order is not preserved wrt to the vocs causing errors.
So now we are adding in control variables while initializing the fixedvariablemodel class 

```
prior = FixedVariableModel(
    model=model,
    fixed_values = fixed_variable_values,
    control_variables = vocs.variable_names)
```