### PR TITLE
Removing shape validation

### DIFF
--- a/lume_torch/variables.py
+++ b/lume_torch/variables.py
@@ -255,27 +255,15 @@ class TorchScalarVariable(_BaseScalarVariable):
             self.validate_value(self.default_value, ConfigEnum.ERROR)
         return self
 
-    def _unbatch(self, value: Tensor) -> Tensor:
-        """Unbatch a tensor with a batch dimension."""
+    def _unbatch(self, value: Tensor) -> tuple:
+        """Unbatch a tensor with arbitrary batch dimensions into individual scalar elements."""
         if value.ndim == 0:
             return (value,)
-        elif value.ndim > 0 and value.shape[-1] == 1:
-            return value.flatten()
-        else:
-            raise ValueError(
-                f"Expected a 0D scalar tensor or a 1D tensor with a single element in the "
-                f"last dimension, but got {value.ndim} dimensions with shape {value.shape}. "
-            )
+        return tuple(value.flatten())
 
     def _validate_value_type(self, value):
-        """Validates that value is a 0D/1D torch.Tensor or a regular float/int."""
-        if isinstance(value, Tensor):
-            if value.ndim != 0 and not (value.ndim == 1 and value.shape[0] == 1):
-                raise ValueError(
-                    f"Expected a 0D scalar tensor or a 1D tensor with a single element, "
-                    f"but got {value.ndim} dimensions with shape {value.shape}. "
-                )
-        else:
+        """Validates that value is a torch.Tensor or a regular float/int."""
+        if not isinstance(value, Tensor):
             # Delegate to parent class for non-tensor validation
             _BaseScalarVariable._validate_value_type(value)
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -168,11 +168,12 @@ class TestTorchScalarVariable:
         var = TorchScalarVariable(name="test")
         var.validate_value(torch.tensor([[5.0], [6.0]]))
 
-    def test_validate_value_tensor_nd_rejects_non_scalar(self):
-        """Test that tensors with more than 1 element are rejected."""
+    def test_validate_value_tensor_nd_accepts_arbitrary_shape(self):
+        """Test that tensors with arbitrary shape are accepted (no shape validation)."""
         var = TorchScalarVariable(name="test")
-        with pytest.raises(ValueError, match="Expected a 0D scalar"):
-            var.validate_value(torch.tensor([5.0, 6.0]))
+        var.validate_value(torch.tensor([5.0, 6.0]))
+        var.validate_value(torch.tensor([[1.0, 2.0], [3.0, 4.0]]))
+        var.validate_value(torch.rand(2, 3, 4))
 
     def test_validate_batched_checks_every_sample_error(self):
         """Batched scalar validation should apply value-range checks to every sample."""


### PR DESCRIPTION
This PR removes the strict shape validation from TorchScalarVariable to allow tensors with arbitrary batch dimensions.

Changes:

_validate_value_type: Removed the check that rejected tensors with more than 1 element. Now any tensor shape is accepted; only non-tensor values are delegated to the parent validator for type checking.

_unbatch: Simplified to flatten any tensor into individual scalar elements regardless of shape. Previously required [n, 1] trailing dimension; now supports arbitrary shapes like [batch, n], [batch, n, 1], [a, b, c], etc.

Test update: Changed test_validate_value_tensor_nd_rejects_non_scalar  -> test_validate_value_tensor_nd_accepts_arbitrary_shap, which now asserts that multi-element tensors of various shapes pass validation successfully.

Motivation: Allow scalar variables to accept tensors with arbitrary batch dimensions (e.g. [batch, n, 1] or [batch, n]) without shape constraints, treating all elements as individual scalar samples for dtype and range validation.