### PR TITLE
Populate cache with defaults at initialization in LUMETorchModel

### DIFF
--- a/lume_torch/base.py
+++ b/lume_torch/base.py
@@ -934,6 +934,18 @@ class LUMETorchModel(LUMEModel):
         self._supported_variables = self._build_supported_variables()
         self._initialized: bool = False
 
+        # Best-effort default initialization: when every input variable has a
+        # default_value, populate the cache (inputs + computed outputs) so get()
+        # works before any explicit set(). Models with an input lacking a default
+        # stay lazy and initialize on first set().
+        if all(
+            getattr(var, "default_value", None) is not None
+            for var in self.torch_model.input_variables
+        ):
+            self._set({})
+
+        self._initial_cache: dict[str, Any] = dict(self._cache)
+
     def _build_supported_variables(self) -> dict[str, Variable]:
         """Build the supported-variables dict once.
 
@@ -1037,14 +1049,15 @@ class LUMETorchModel(LUMEModel):
 
     def reset(self) -> None:
         """
-        Clear the input/output cache and reset initialization state.
+        Reset to the initial state captured at construction.
 
-        For stateless surrogate models, this simply clears the cached values
-        and resets the initialization flag. The model itself has no internal
-        state to reset.
+        For models whose inputs are all defaulted this restores the
+        default-populated cache (inputs + computed outputs), so get() works
+        after reset() exactly as after construction. For models that were not
+        default-initialized this restores an empty cache.
         """
-        self._cache.clear()
-        self._initialized = False
+        self._cache = dict(self._initial_cache)
+        self._initialized = bool(self._initial_cache)
 
     @property
     def supported_variables(self) -> dict[str, Variable]:

--- a/lume_torch/base.py
+++ b/lume_torch/base.py
@@ -934,7 +934,7 @@ class LUMETorchModel(LUMEModel):
         self._supported_variables = self._build_supported_variables()
         self._initialized: bool = False
 
-        # Best-effort default initialization: when every input variable has a
+        # Default initialization: when every input variable has a
         # default_value, populate the cache (inputs + computed outputs) so get()
         # works before any explicit set(). Models with an input lacking a default
         # stay lazy and initialize on first set().

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -264,14 +264,34 @@ class TestLUMETorchModel:
         return SimpleModel(**simple_variables)
 
     def test_init_with_torch_model(self, simple_torch_model):
-        """Test initialization of LUMETorchModel with a torch model."""
+        """Fully-defaulted inputs are set at construction (inputs + outputs)."""
         wrapper = LUMETorchModel(simple_torch_model)
         assert wrapper.torch_model == simple_torch_model
-        assert wrapper._cache == {}  # Starts with empty cache
+        assert wrapper._initialized is True
+        assert wrapper._cache["input1"] == 1.0
+        assert wrapper._cache["input2"] == 2.0
+        assert wrapper._cache["output1"] == 2.0  # 1.0 * 2
+        assert wrapper._cache["output2"] == 4.0  # 2.0 * 2
 
-    def test_get_before_set_raises_error(self, simple_torch_model):
-        """Test that calling get() before set() raises a helpful error."""
-        wrapper = LUMETorchModel(simple_torch_model)
+    def test_get_before_set_raises_error(self):
+        """A model with an input lacking a default is not auto-initialized, so
+        get() before set() still raises a helpful error."""
+        model = SimpleModel(
+            input_variables=[
+                TorchScalarVariable(
+                    name="input1", value_range=(0.0, 5.0)
+                ),  # no default
+                TorchScalarVariable(
+                    name="input2", default_value=2.0, value_range=(1.0, 3.0)
+                ),
+            ],
+            output_variables=[
+                TorchScalarVariable(name="output1"),
+                TorchScalarVariable(name="output2"),
+            ],
+        )
+        wrapper = LUMETorchModel(model)
+        assert wrapper._initialized is False
 
         # Trying to get values before setting any inputs should raise KeyError
         with pytest.raises(KeyError) as exc_info:
@@ -323,21 +343,20 @@ class TestLUMETorchModel:
         assert variables["output2"].read_only is True
 
     def test_reset(self, simple_torch_model):
-        """Test reset functionality clears the cache."""
+        """Test reset restores the default-initialized state."""
         wrapper = LUMETorchModel(simple_torch_model)
 
-        # Set initial state
-        wrapper.set({"input1": 2.0, "input2": 1.5})
-        assert wrapper._cache["input1"] == 2.0
-        assert wrapper._cache["output1"] == 4.0
-
-        # Change state
+        # Change state away from the construction defaults
         wrapper.set({"input1": 5.0})
         assert wrapper._cache["input1"] == 5.0
 
-        # Reset clears the cache
+        # Reset restores the default-populated cache, not an empty one
         wrapper.reset()
-        assert wrapper._cache == {}
+        assert wrapper._initialized is True
+        assert wrapper._cache["input1"] == 1.0
+        assert wrapper._cache["input2"] == 2.0
+        assert wrapper._cache["output1"] == 2.0  # 1.0 * 2
+        assert wrapper._cache["output2"] == 4.0  # 2.0 * 2
 
     def test_dump_and_load(self, simple_torch_model, tmp_path):
         """Test dumping and loading the wrapper."""


### PR DESCRIPTION
This pull request improves the initialization and reset behavior of the `LUMETorchModel` class to better support models with default input values. Now, if all input variables have defaults, the model is automatically initialized at construction, and resets restore this default-populated state instead of clearing the cache. The tests have been updated to reflect and verify these changes.

This is needed now for compatibility with the VA sims and latest `lume-pva` runner changes that cache the model values at each run, which calls `get` before `set` at runtime.

### Initialization and Reset Behavior Improvements

* Added best-effort default initialization in `LUMETorchModel.__init__`: if all input variables have a `default_value`, the input and output caches are populated at construction, making `get()` usable before any explicit `set()` call. Models with missing input defaults remain lazy-initialized. (`lume_torch/base.py`)
* Modified the `reset()` method to restore the initial state captured at construction (including default-populated cache and initialization flag), rather than simply clearing the cache. (`lume_torch/base.py`)

### Test Suite Updates

* Updated tests to verify that fully-defaulted models are initialized at construction, and that models with missing input defaults still require explicit `set()` before `get()`. (`tests/test_base.py`)
* Updated the reset test to confirm that `reset()` restores the default-populated cache rather than emptying it, and checks for correct values after reset. (`tests/test_base.py`)